### PR TITLE
Reorder RDA file loading logic

### DIFF
--- a/AnnoMapEditor/DataArchives/RdaDataArchive.cs
+++ b/AnnoMapEditor/DataArchives/RdaDataArchive.cs
@@ -60,8 +60,8 @@ namespace AnnoMapEditor.DataArchives
                     .Where(x => System.IO.Path.GetFileName(x).StartsWith("data") && 
                         !x.EndsWith("data0.rda") && !x.EndsWith("data1.rda") && !x.EndsWith("data2.rda") && !x.EndsWith("data3.rda") && 
                         !x.EndsWith("data4.rda") && !x.EndsWith("data7.rda") && !x.EndsWith("data8.rda") && !x.EndsWith("data9.rda"))
-                    // load highest numbers first
-                    .Reverse();
+                    // load highest numbers last to overwrite lower numbers
+                    .OrderBy(x => int.TryParse(System.IO.Path.GetFileNameWithoutExtension(x)["data".Length..], out int result) ? result : 0);
                 readers = archives.Select(x =>
                 {
                     try


### PR DESCRIPTION
RDA files loaded later in the order overwrite the files extracted from prior files in allFiles[].
This change makes sure that higher-numbered files are loaded later, and uses ordering not on a per-character basis but on the number X in the "dataX.rda" file.

This order is likely to be correct due to the later changes being used ingame based on this observation:
- data5 archipel_ll is almost right but only has 1 spawn point
- data10 archipel_ll has a different island layout than the game uses
- data11 archipel_ll has the right layout and 4 spawn points -> it should be the right file

This PR fixes #11 and fixes #13 