### PR TITLE
Starting Point Count for new maps

### DIFF
--- a/AnnoMapEditor/MapTemplates/Island.cs
+++ b/AnnoMapEditor/MapTemplates/Island.cs
@@ -103,12 +103,12 @@ namespace AnnoMapEditor.MapTemplates
 
         public static List<Island> CreateNewStartingSpots(int playableSize, int margin, Region region)
         {
-            const int SPACING = 32;
+            const int SPACING = 64;
 
             List<Island> starts = new List<Island>()
             {
                 CreateStartingSpot(region, margin + SPACING, playableSize + margin - SPACING),
-                CreateStartingSpot(region, margin + SPACING, playableSize + margin - 2* SPACING),
+                CreateStartingSpot(region, margin + SPACING, playableSize + margin - 2*SPACING),
                 CreateStartingSpot(region, margin + 2*SPACING, playableSize + margin - SPACING),
                 CreateStartingSpot(region, margin + 2*SPACING, playableSize + margin - 2*SPACING),
             };

--- a/AnnoMapEditor/MapTemplates/Session.cs
+++ b/AnnoMapEditor/MapTemplates/Session.cs
@@ -132,9 +132,12 @@ namespace AnnoMapEditor.MapTemplates
                 template = createdTemplateDoc
             };
 
-            foreach (Island s in startingSpots)
+
+            int startingSpotCounter = 0;
+            foreach (Island startingSpot in startingSpots)
             {
-                session.AddIsland(s);
+                startingSpot.Counter = startingSpotCounter++;
+                session.AddIsland(startingSpot);
             }
 
             if (session.Size.X == 0)


### PR DESCRIPTION
The starting points generated when creating an empty map now get numbered to show up as Player + AI 1-3 starts.