### PR TITLE
Change Start location Marker to Map Pin Shape

### DIFF
--- a/AnnoMapEditor/UI/Controls/MapObject.xaml
+++ b/AnnoMapEditor/UI/Controls/MapObject.xaml
@@ -28,14 +28,14 @@
                 Grid.Column="0"
                 Width="64"
                 Height="64"
-                CornerRadius="32"
+                CornerRadius="32,32,32,0"
                 Background="#ffff00"
-                VerticalAlignment="Center" HorizontalAlignment="Center"
-                RenderTransformOrigin=".5,.5">
-            <Border.RenderTransform>
-                <RotateTransform Angle="45" />
-            </Border.RenderTransform>
-            <TextBlock Foreground="Black" Name="startNumber" FontSize="50" TextAlignment="Center" />
+                VerticalAlignment="Center" HorizontalAlignment="Center">
+            <TextBlock Foreground="Black" Name="startNumber" FontSize="50" TextAlignment="Center" RenderTransformOrigin=".5,.5">
+                <TextBlock.RenderTransform>
+                    <RotateTransform Angle="45" />
+                </TextBlock.RenderTransform>
+            </TextBlock>
         </Border>
 
         <Grid

--- a/AnnoMapEditor/UI/Controls/MapObject.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapObject.xaml.cs
@@ -159,11 +159,13 @@ namespace AnnoMapEditor.UI.Controls
 
             canvas.Children.Clear();
 
+            const int MAP_PIN_SIZE = 64;
+
             if (island.ElementType == 2)
             {
-                Width = 64;
-                Height = 64;
-                this.SetPosition((island.Position - new Vector2(32, 32)).FlipY(session.Size.Y));
+                Width = MAP_PIN_SIZE;
+                Height = MAP_PIN_SIZE;
+                this.SetPosition((island.Position).FlipYItem(session.Size.Y, MAP_PIN_SIZE));
                 Panel.SetZIndex(this, 100);
 
                 // TODO the order of AIs is odd, may be incorrect?


### PR DESCRIPTION
The previous 64x64 start location circle was placed counterintuitively. It was placed so its imaginary surrounding square had its left corner at the target coordinate. This was changed so that the bottom corner instead defines the coordinate (like with islands), while the shape was changed to a map pin to more accurately denote the placement location.

![Old positioning](https://user-images.githubusercontent.com/15235997/189698323-d05d8bb6-3fc2-457e-8b31-706e1fea8587.png)
(Old positioning, island and start have the same coordinates)

![New positioning](https://user-images.githubusercontent.com/15235997/189698560-c7d4d934-a303-4575-8227-41150b57bd42.png)
(New positioning, island and start have the same coordinate)