### PR TITLE
Feature/cleanup island

### DIFF
--- a/AnnoMapEditor/MapTemplates/Island.cs
+++ b/AnnoMapEditor/MapTemplates/Island.cs
@@ -287,7 +287,7 @@ namespace AnnoMapEditor.MapTemplates
 
             if (mapPath == null)
             {
-                mapPath = region.GetRandomIslandPath(Size);
+                mapPath = region.IslandMapPools[Size].GetRandomMap().FilePath;
                 Rotation = rnd.Next(0, 3);
             }
 

--- a/AnnoMapEditor/MapTemplates/Islands/IslandMap.cs
+++ b/AnnoMapEditor/MapTemplates/Islands/IslandMap.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Islands
+{
+    public class IslandMap
+    {
+        public string FilePath { get; }
+
+        public int SizeInTiles { get; }
+
+
+        public IslandMap(string filePath, int sizeInTiles)
+        {
+            FilePath = filePath;
+            SizeInTiles = sizeInTiles;
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Islands/IslandMapPool.cs
+++ b/AnnoMapEditor/MapTemplates/Islands/IslandMapPool.cs
@@ -1,0 +1,51 @@
+﻿using AnnoMapEditor.MapTemplates.Serializing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Islands
+{
+    public class IslandMapPool
+    {
+        private readonly IslandMap[] IslandMaps;
+
+        public int Size => IslandMaps.Length;
+
+
+        private IslandMapPool(params IslandMap[] islandMaps)
+        {
+            IslandMaps = islandMaps;
+        }
+
+
+        public static IslandMapPool Create(string filePathTemplate, int size)
+            => Create(filePathTemplate, Enumerable.Range(0, size));
+
+        public static IslandMapPool Create(string filePathTemplate, IEnumerable<int> indices)
+        {
+            IEnumerable<IslandMap> islandMaps = indices.Select(index =>
+            {
+                string mapFilePath = string.Format(filePathTemplate, string.Format("{0:00}", index));
+                int sizeInTiles = Task.Run(() => IslandReader.ReadTileInSizeFromFileAsync(mapFilePath)).Result;
+                return new IslandMap(mapFilePath, sizeInTiles);
+            });
+
+            return new IslandMapPool(islandMaps.ToArray());
+        }
+
+
+        public IslandMap GetRandomMap()
+        {
+            int index = Random.Shared.Next(IslandMaps.Length);
+            return IslandMaps[index];
+        }
+
+        public IslandMap GetFromFilePath(string filePath)
+        {
+            return IslandMaps.FirstOrDefault(m => m.FilePath == filePath)
+                ?? throw new NullReferenceException();
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Region.cs
+++ b/AnnoMapEditor/MapTemplates/Region.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AnnoMapEditor.MapTemplates.Islands;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,81 +15,49 @@ namespace AnnoMapEditor.MapTemplates
         public static readonly Region Moderate = new("Moderate", "Moderate", "Moderate_01_day_night", 
             new()
             {
-                [IslandSize.Small] = new Pool("data/sessions/islands/pool/moderate/moderate_s_{0}/moderate_s_{0}.a7m", 12),
-                [IslandSize.Medium] = new Pool("data/sessions/islands/pool/moderate/moderate_m_{0}/moderate_m_{0}.a7m", 9),
-                [IslandSize.Large] = new Pool("data/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 14)
+                [IslandSize.Small]  = IslandMapPool.Create("data/sessions/islands/pool/moderate/moderate_s_{0}/moderate_s_{0}.a7m", 12),
+                [IslandSize.Medium] = IslandMapPool.Create("data/sessions/islands/pool/moderate/moderate_m_{0}/moderate_m_{0}.a7m", 9),
+                [IslandSize.Large]  = IslandMapPool.Create("data/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 14)
             });
         public static readonly Region NewWorld = new("NewWorld", "New World", "south_america_caribic_01",
             new()
             {
-                [IslandSize.Small] = new Pool("data/sessions/islands/pool/colony01/colony01_s_{0}/colony01_s_{0}.a7m", 4),
-                [IslandSize.Medium] = new Pool("data/sessions/islands/pool/colony01/colony01_m_{0}/colony01_m_{0}.a7m", 6),
-                [IslandSize.Large] = new Pool("data/sessions/islands/pool/colony01/colony01_l_{0}/colony01_l_{0}.a7m", 5)
+                [IslandSize.Small]  = IslandMapPool.Create("data/sessions/islands/pool/colony01/colony01_s_{0}/colony01_s_{0}.a7m", 4),
+                [IslandSize.Medium] = IslandMapPool.Create("data/sessions/islands/pool/colony01/colony01_m_{0}/colony01_m_{0}.a7m", 6),
+                [IslandSize.Large]  = IslandMapPool.Create("data/sessions/islands/pool/colony01/colony01_l_{0}/colony01_l_{0}.a7m", 5)
             });
         public static readonly Region Arctic = new("Arctic", "Arctic", "DLC03_01",
             new()
             {
-                [IslandSize.Small] = new Pool("data/dlc03/sessions/islands/pool/colony03_a01_{0}/colony03_a01_{0}.a7m", 8),
-                [IslandSize.Medium] = new Pool("data/dlc03/sessions/islands/pool/colony03_a02_{0}/colony03_a02_{0}.a7m", 4),
-                [IslandSize.Large] = new Pool("data/dlc03/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 14)
+                [IslandSize.Small]  = IslandMapPool.Create("data/dlc03/sessions/islands/pool/colony03_a01_{0}/colony03_a01_{0}.a7m", 8),
+                [IslandSize.Medium] = IslandMapPool.Create("data/dlc03/sessions/islands/pool/colony03_a02_{0}/colony03_a02_{0}.a7m", 4),
+                [IslandSize.Large]  = IslandMapPool.Create("data/dlc03/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 14)
             });
         public static readonly Region Enbesa = new("Enbesa", "Enbesa", "Colony_02",
             new()
             {
-                [IslandSize.Small] = new Pool("data/dlc06/sessions/islands/pool/colony02_s_{0}/colony02_s_{0}.a7m", new int[] { 1, 2, 3, 5 }),
-                [IslandSize.Medium] = new Pool("data/dlc06/sessions/islands/pool/colony02_m_{0}/colony02_m_{0}.a7m", new int[] { 2, 4, 5, 9 }),
-                [IslandSize.Large] = new Pool("data/dlc06/sessions/islands/pool/colony02_l_{0}/colony02_l_{0}.a7m", new int[] { 1, 3, 5, 6 })
+                [IslandSize.Small]  = IslandMapPool.Create("data/dlc06/sessions/islands/pool/colony02_s_{0}/colony02_s_{0}.a7m", new int[] { 1, 2, 3, 5 }),
+                [IslandSize.Medium] = IslandMapPool.Create("data/dlc06/sessions/islands/pool/colony02_m_{0}/colony02_m_{0}.a7m", new int[] { 2, 4, 5, 9 }),
+                [IslandSize.Large]  = IslandMapPool.Create("data/dlc06/sessions/islands/pool/colony02_l_{0}/colony02_l_{0}.a7m", new int[] { 1, 3, 5, 6 })
             });
         public static readonly Region[] All = new Region[] { Moderate, NewWorld, Arctic, Enbesa };
         #endregion
 
+
         public string Name { get; init; }
         public string AmbientName { get; init; }
 
-        private static readonly Random rnd = new((int)DateTime.Now.Ticks);
-
         private readonly string value;
 
-        #region Pool Islands
-        public struct Pool
-        {
-            public string filePath;
-            public int size;
-            public int[]? ids;
+        public Dictionary<IslandSize, IslandMapPool> IslandMapPools { get; private init; }
 
-            public Pool(string filePath, int size)
-            {
-                this.filePath = filePath;
-                this.size = size;
-                ids = null;
-            }
 
-            public Pool(string filePath, int[] ids)
-            {
-                this.filePath = filePath;
-                size = ids.Length;
-                this.ids = ids;
-            }
-        }
-        public Dictionary<IslandSize, Pool> PoolIslands { get; private init; }
-        #endregion
-
-        private Region(string type, string name, string ambientName, Dictionary<IslandSize, Pool> poolIslands)
+        private Region(string type, string name, string ambientName, Dictionary<IslandSize, IslandMapPool> islandMapPools)
         {
             value = type;
             Name = name;
             AmbientName = ambientName;
-            PoolIslands = poolIslands;
-        }
-
-        public string GetRandomIslandPath(IslandSize size)
-        {
-            int index = rnd.Next(1, PoolIslands[size].size);
-            var ids = PoolIslands[size].ids;
-            if (ids is not null)
-                index = ids[index];
-
-            return string.Format(PoolIslands[size].filePath, string.Format("{0:00}", index));
+            IslandMapPools = islandMapPools;
         }
 
         public override string ToString() => value;

--- a/AnnoMapEditor/MapTemplates/Session.cs
+++ b/AnnoMapEditor/MapTemplates/Session.cs
@@ -56,7 +56,7 @@ namespace AnnoMapEditor.MapTemplates
             if (doc is null)
                 return null;
 
-            return await FromTemplateDocument(doc, DetectRegionFromPath(internalPath));
+            return FromTemplateDocument(doc, DetectRegionFromPath(internalPath));
         }
 
         public static async Task<Session?> FromXmlAsync(string filePath)
@@ -65,7 +65,7 @@ namespace AnnoMapEditor.MapTemplates
             if (doc is null)
                 return null;
 
-            return await FromTemplateDocument(doc, DetectRegionFromPath(filePath));
+            return FromTemplateDocument(doc, DetectRegionFromPath(filePath));
         }
 
         public static async Task<Session?> FromXmlAsync(Stream? stream, string internalPath)
@@ -74,10 +74,10 @@ namespace AnnoMapEditor.MapTemplates
             if (doc is null)
                 return null;
 
-            return await FromTemplateDocument(doc, DetectRegionFromPath(internalPath));
+            return FromTemplateDocument(doc, DetectRegionFromPath(internalPath));
         }
 
-        public static async Task<Session?> FromTemplateDocument(MapTemplateDocument document, Region region)
+        public static Session? FromTemplateDocument(MapTemplateDocument document, Region region)
         {
             var islands = from element in document.MapTemplate?.TemplateElement
                           where element?.Element is not null
@@ -85,7 +85,7 @@ namespace AnnoMapEditor.MapTemplates
             Session session = new()
             {
                 Region = region,
-                _islands = new List<Island>(await Task.WhenAll(islands)),
+                _islands = islands.ToList(),
                 Size = new Vector2(document.MapTemplate?.Size),
                 PlayableArea = new Rect2(document.MapTemplate?.PlayableArea),
                 template = document
@@ -177,16 +177,16 @@ namespace AnnoMapEditor.MapTemplates
             MapSizeConfigCommitted?.Invoke(this, new EventArgs());
         }
 
-        public async Task UpdateExternalDataAsync()
+        public void UpdateExternalData()
         {
             foreach (var island in Islands)
-                await island.UpdateExternalDataAsync();
+                island.UpdateExternalData();
         }
 
-        public async Task UpdateAsync()
+        public void Update()
         {
             foreach (var island in Islands)
-                await island.InitAsync(Region);
+                island.Init(Region);
         }
 
         public MapTemplateDocument? ToTemplate()
@@ -229,7 +229,7 @@ namespace AnnoMapEditor.MapTemplates
         {
             island.CreateTemplate();
             _islands.Add(island);
-            Task.Run(async () => await island.InitAsync(Region));
+            island.Init(Region);
             IslandCollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 

--- a/AnnoMapEditor/UI/Controls/IslandProperties.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/IslandProperties.xaml.cs
@@ -67,7 +67,7 @@ namespace AnnoMapEditor.UI.Controls
             island.IsStarter = IsStarterCheckBox.IsChecked;
         }
 
-        private async void OnTypeSelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void OnTypeSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (DataContext is Island island && TypeComboBox.SelectedItem is UserIslandType type)
             {
@@ -76,10 +76,8 @@ namespace AnnoMapEditor.UI.Controls
                     island.Size = type.Size;
                     if (type.Size == IslandSize.Small || !island.Type.IsSameWithoutOil(type.Type))
                         island.Type = type.Type;
-                    island.MapPath = null;
-
-                    // triggers reselection from pool
-                    await island.UpdateAsync();
+                    
+                    island.RandomizeMap();
                 }
             }
         }

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -81,12 +81,12 @@ namespace AnnoMapEditor.UI.Controls
             UpdateIslands(DataContext as Session);
         }
 
-        private async void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (DataContext is not Session session)
                 return;
 
-            await session.UpdateExternalDataAsync();
+            session.UpdateExternalData();
             UpdateIslands(session);
         }
 

--- a/AnnoMapEditor/UI/Models/SessionChecker.cs
+++ b/AnnoMapEditor/UI/Models/SessionChecker.cs
@@ -76,17 +76,17 @@ namespace AnnoMapEditor.UI.Models
                 pools[0] -= pirateCount - 1;
             }
             
-            if (pools[0] > session.Region.PoolIslands[IslandSize.Small].size)
+            if (pools[0] > session.Region.IslandMapPools[IslandSize.Small].Size)
             {
-                Status = $"⚠ Too many small pool islands.\nOnly the first {session.Region.PoolIslands[IslandSize.Small].size} islands will be loaded.\nThird party and pirate islands\nare considered small pool islands if deactivated.";
+                Status = $"⚠ Too many small pool islands.\nOnly the first {session.Region.IslandMapPools[IslandSize.Small].Size} islands will be loaded.\nThird party and pirate islands\nare considered small pool islands if deactivated.";
             }
-            else if (pools[1] > session.Region.PoolIslands[IslandSize.Medium].size)
+            else if (pools[1] > session.Region.IslandMapPools[IslandSize.Medium].Size)
             {
-                Status = $"⚠ Too many medium pool islands.\nOnly the first {session.Region.PoolIslands[IslandSize.Medium].size} islands will be loaded.";
+                Status = $"⚠ Too many medium pool islands.\nOnly the first {session.Region.IslandMapPools[IslandSize.Medium].Size} islands will be loaded.";
             }
-            else if (pools[2] > session.Region.PoolIslands[IslandSize.Large].size)
+            else if (pools[2] > session.Region.IslandMapPools[IslandSize.Large].Size)
             {
-                Status = $"⚠ Too many large pool islands.\nOnly the first {session.Region.PoolIslands[IslandSize.Large].size} islands will be loaded.";
+                Status = $"⚠ Too many large pool islands.\nOnly the first {session.Region.IslandMapPools[IslandSize.Large].Size} islands will be loaded.";
             }
             else if (pools[0] < 0)
             {

--- a/AnnoMapEditor/UI/Models/SessionPropertiesViewModel.cs
+++ b/AnnoMapEditor/UI/Models/SessionPropertiesViewModel.cs
@@ -30,7 +30,7 @@ namespace AnnoMapEditor.UI.Models
                 {
                     _selectedRegion = value;
                     _session.Region = value;
-                    _ = _session.UpdateAsync();
+                    _session.Update();
                     OnSelectedRegionChanged();
                 }
             }


### PR DESCRIPTION
I noticed that almost all of the async/await in `Island` and `Session` is due to `Island.SizeInTiles`. It is loaded lazily and asynchronously in `Island.UpdateExternalDataAsync`. This being async propagates throughout the classes and leads to all kinds of jank.

I refactored the `IslandMapPool` to load all of the maps' sizes on initialization of the pools. This removes the necessity of most async/awaits throughout these classes.