### PR TITLE
Simplify editor coordinate system

### DIFF
--- a/AnnoMapEditor/MapTemplates/Island.cs
+++ b/AnnoMapEditor/MapTemplates/Island.cs
@@ -137,16 +137,17 @@ namespace AnnoMapEditor.MapTemplates
             return island;
         }
 
-        public static List<Island> CreateNewStartingSpots(int playableSize, int margin, Region region)
+        public static List<Island> CreateNewStartingSpots(int mapSize, int margin, Region region)
         {
-            const int SPACING = 64;
+            const int SPACING = 32;
+            int halfSize = mapSize / 2;
 
             List<Island> starts = new List<Island>()
             {
-                CreateStartingSpot(region, margin + SPACING, playableSize + margin - SPACING),
-                CreateStartingSpot(region, margin + SPACING, playableSize + margin - 2*SPACING),
-                CreateStartingSpot(region, margin + 2*SPACING, playableSize + margin - SPACING),
-                CreateStartingSpot(region, margin + 2*SPACING, playableSize + margin - 2*SPACING),
+                CreateStartingSpot(region, halfSize + SPACING, halfSize + SPACING),
+                CreateStartingSpot(region, halfSize + SPACING, halfSize - SPACING),
+                CreateStartingSpot(region, halfSize - SPACING, halfSize - SPACING),
+                CreateStartingSpot(region, halfSize - SPACING, halfSize + SPACING),
             };
 
             return starts;
@@ -186,15 +187,19 @@ namespace AnnoMapEditor.MapTemplates
 
             //Create a fully new templateElement for export, so unwanted values are clean
             templateElement.Element = new Element();
+
+            // The editor's coordinate system's axis are flipped compared to Anno1800. Thus we must
+            // flip X and Y when serializing.
+            templateElement.Element.Position = new int[] { this.Position.Y, this.Position.X };
+
             switch (this.ElementType)
             {
                 //Starting spot
                 case 2:
-                    templateElement.Element.Position = new int[] { this.Position.X, this.Position.Y };
                     break;
+
                 //Pool island
                 case 1:
-                    templateElement.Element.Position = new int[] { this.Position.X, this.Position.Y };
                     templateElement.Element.Size = this.Size.ElementValue;
                     templateElement.Element.Difficulty = new Difficulty();
                     templateElement.Element.Config = new Config()
@@ -209,7 +214,6 @@ namespace AnnoMapEditor.MapTemplates
                     if (MapPath == null)
                         return null;
 
-                    templateElement.Element.Position = new int[] { this.Position.X, this.Position.Y };
                     templateElement.Element.MapFilePath = MapPath;
                     templateElement.Element.Rotation90 = (byte)this.Rotation;
 

--- a/AnnoMapEditor/MapTemplates/Math.cs
+++ b/AnnoMapEditor/MapTemplates/Math.cs
@@ -93,11 +93,6 @@ namespace AnnoMapEditor.MapTemplates
             return new Vector2(Math.Clamp(X, min.X, max.X), Math.Clamp(Y, min.Y, max.Y));
         }
 
-        public Vector2 FlipY(int sessionSizeY)
-        {
-            return new Vector2(X, sessionSizeY - Y);
-        }
-
         public Vector2 FlipYItem(int sessionSizeY, int itemSizeY)
         {
             return new Vector2(X, sessionSizeY - itemSizeY - Y);

--- a/AnnoMapEditor/MapTemplates/Session.cs
+++ b/AnnoMapEditor/MapTemplates/Session.cs
@@ -111,7 +111,7 @@ namespace AnnoMapEditor.MapTemplates
         {
             int margin = (mapSize - playableSize) / 2;
 
-            List<Island> startingSpots = Island.CreateNewStartingSpots(playableSize, margin, region);
+            List<Island> startingSpots = Island.CreateNewStartingSpots(mapSize, margin, region);
 
             MapTemplateDocument createdTemplateDoc = new MapTemplateDocument()
             {

--- a/AnnoMapEditor/UI/Controls/MapObject.xaml
+++ b/AnnoMapEditor/UI/Controls/MapObject.xaml
@@ -4,15 +4,24 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls"
+    xmlns:converters="clr-namespace:AnnoMapEditor.UI.Converters"
     mc:Ignorable="d"
     d:DesignHeight="192" d:DesignWidth="192"
     Width="1"
     Height="1">
+
+    <UserControl.Resources>
+        <converters:NegateDoubleConverter x:Key="negateDoubleConverter" />
+    </UserControl.Resources>
+    
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
+
         <Canvas Name="canvas" Grid.Column="0" />
+
         <Border Name="titleBackground" Grid.Column="0"
                 CornerRadius="10"
                 Padding="4,0,4,0"
@@ -20,20 +29,21 @@
                 VerticalAlignment="Center" HorizontalAlignment="Center"
                 RenderTransformOrigin=".5,.5">
             <Border.RenderTransform>
-                <RotateTransform Angle="45" />
+                <RotateTransform Angle="{Binding Source={x:Static local:MapView.MAP_ROTATION_ANGLE}, Converter={StaticResource negateDoubleConverter}}" />
             </Border.RenderTransform>
             <TextBlock Foreground="White"  Name="title" FontSize="50" TextAlignment="Center" />
         </Border>
+        
         <Border Name="startPosition"
                 Grid.Column="0"
-                Width="64"
-                Height="64"
-                CornerRadius="32,32,32,0"
+                Width="{Binding Source={x:Static local:MapObject.MAP_PIN_SIZE}}"
+                Height="{Binding Source={x:Static local:MapObject.MAP_PIN_SIZE}}"
+                CornerRadius="{Binding Source={x:Static local:MapObject.MAP_PIN_BORDER}}"
                 Background="#ffff00"
                 VerticalAlignment="Center" HorizontalAlignment="Center">
             <TextBlock Foreground="Black" Name="startNumber" FontSize="50" TextAlignment="Center" RenderTransformOrigin=".5,.5">
                 <TextBlock.RenderTransform>
-                    <RotateTransform Angle="45" />
+                    <RotateTransform Angle="{Binding Source={x:Static local:MapView.MAP_ROTATION_ANGLE}, Converter={StaticResource negateDoubleConverter}}" />
                 </TextBlock.RenderTransform>
             </TextBlock>
         </Border>

--- a/AnnoMapEditor/UI/Controls/MapObject.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapObject.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using System.Windows.Input;
 using System.Windows.Shapes;
 using System.Windows.Media.Imaging;
+using AnnoMapEditor.UI.Utilities;
 
 namespace AnnoMapEditor.UI.Controls
 {

--- a/AnnoMapEditor/UI/Controls/MapObject.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapObject.xaml.cs
@@ -48,7 +48,8 @@ namespace AnnoMapEditor.UI.Controls
         readonly Session session;
         readonly MapView container;
 
-        public const int MAP_PIN_SIZE = 64;
+        public static readonly int MAP_PIN_SIZE = 64;
+        public static readonly CornerRadius MAP_PIN_BORDER = new(0, MAP_PIN_SIZE / 2, MAP_PIN_SIZE / 2, MAP_PIN_SIZE / 2);
 
         public Vector2 MouseOffset;
 
@@ -166,7 +167,7 @@ namespace AnnoMapEditor.UI.Controls
             {
                 Width = MAP_PIN_SIZE;
                 Height = MAP_PIN_SIZE;
-                this.SetPosition((island.Position).FlipYItem(session.Size.Y, MAP_PIN_SIZE));
+                this.SetPosition(island.Position);
                 Panel.SetZIndex(this, 100);
 
                 // TODO the order of AIs is odd, may be incorrect?
@@ -187,7 +188,7 @@ namespace AnnoMapEditor.UI.Controls
             {
                 Width = island.SizeInTiles;
                 Height = island.SizeInTiles;
-                this.SetPosition(island.Position.FlipYItem(session.Size.Y, island.SizeInTiles));
+                this.SetPosition(island.Position);
                 Panel.SetZIndex(this, ZIndex[island.Type]);
 
                 Image? image;
@@ -243,7 +244,7 @@ namespace AnnoMapEditor.UI.Controls
                     Fill = White,
                 };
 
-                circle.SetPosition(Vector2.Zero.FlipYItem(island.SizeInTiles, CIRCLE_DIAMETER));
+                circle.SetPosition(Vector2.Zero);
                 canvas.Children.Add(circle);
 
                 if (!string.IsNullOrEmpty(island.Label))

--- a/AnnoMapEditor/UI/Controls/MapView.xaml
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml
@@ -2,15 +2,15 @@
     x:Class="AnnoMapEditor.UI.Controls.MapView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:AnnoMapEditor.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls"
     mc:Ignorable="d">
 
     <Grid Width="auto" Height="auto" VerticalAlignment="Center" HorizontalAlignment="Center">
         <Canvas Name="rotationCanvas" RenderTransformOrigin="0.5, 0.5" Width="0" Height="0">
             <Canvas.RenderTransform>
-                <RotateTransform Angle="-45"/>
+                <RotateTransform Angle="{Binding Source={x:Static local:MapView.MAP_ROTATION_ANGLE}}"/>
             </Canvas.RenderTransform>
             <Canvas 
                 Name="sessionCanvas"

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -15,6 +15,9 @@ namespace AnnoMapEditor.UI.Controls
 {
     public partial class MapView : UserControl
     {
+        public static readonly double MAP_ROTATION_ANGLE = -135;
+
+
         private Session? session { get; set; }
         private Rectangle? mapRect { get; set; }
         private Rectangle? playableRect { get; set; }
@@ -259,7 +262,7 @@ namespace AnnoMapEditor.UI.Controls
                 CreateAddIsland(island.Size, island.Type);
             }
 
-            island.Position = ensured.FlipYItem(session.Size.Y, island.IsStartingSpot ? MapObject.MAP_PIN_SIZE : island.SizeInTiles);
+            island.Position = ensured;
             mapObject.SetPosition(ensured);
             mapObject.IsMarkedForDeletion = !island.IsNew && !ensured.Within(mapArea);
         }
@@ -329,7 +332,7 @@ namespace AnnoMapEditor.UI.Controls
                     }
                     else
                     {
-                        var islandCanvasPos = island.Position.FlipYItem(oldSize!.Y, island.SizeInTiles);
+                        var islandCanvasPos = island.Position;
                         var mapArea = new Rect2(session.Size - island.SizeInTiles + Vector2.Tile);
 
                         mapObject.IsMarkedForDeletion = !islandCanvasPos.Within(mapArea);
@@ -385,7 +388,7 @@ namespace AnnoMapEditor.UI.Controls
                     else
                     {
                         Vector2 canvasLocation = mapObject.GetPosition();
-                        island.Position = canvasLocation.FlipYItem(session.Size.Y, island.SizeInTiles);
+                        island.Position = canvasLocation;
                     }
                 }
             }

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoMapEditor.MapTemplates;
+using AnnoMapEditor.UI.Utilities;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -12,20 +13,6 @@ using System.Windows.Shapes;
 
 namespace AnnoMapEditor.UI.Controls
 {
-    public static class CanvasExtensions
-    {
-        public static void SetPosition(this UIElement that, Vector2 position)
-        {
-            Canvas.SetLeft(that, position.X);
-            Canvas.SetTop(that, position.Y);
-        }
-
-        public static Vector2 GetPosition(this UIElement that)
-        {
-            return new Vector2((int)Canvas.GetLeft(that), (int)Canvas.GetTop(that));
-        }
-    }
-
     public partial class MapView : UserControl
     {
         private Session? session { get; set; }

--- a/AnnoMapEditor/UI/Converters/NegateDoubleConverter.cs
+++ b/AnnoMapEditor/UI/Converters/NegateDoubleConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace AnnoMapEditor.UI.Converters
+{
+    [ValueConversion(typeof(double), typeof(double))]
+    public class NegateDoubleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is double d)
+                return -d;
+            else
+                throw new ArgumentException($"Illegal argument for {nameof(NegateDoubleConverter)}. Argument must be of type double, but got {value.GetType()} instead.");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is double d)
+                return -d;
+            else
+                throw new ArgumentException($"Illegal argument for {nameof(NegateDoubleConverter)}. Argument must be of type double, but got {value.GetType()} instead.");
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Utilities/CanvasExtensions.cs
+++ b/AnnoMapEditor/UI/Utilities/CanvasExtensions.cs
@@ -1,0 +1,20 @@
+﻿using AnnoMapEditor.MapTemplates;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace AnnoMapEditor.UI.Utilities
+{
+    public static class CanvasExtensions
+    {
+        public static void SetPosition(this UIElement that, Vector2 position)
+        {
+            Canvas.SetLeft(that, position.X);
+            Canvas.SetTop(that, position.Y);
+        }
+
+        public static Vector2 GetPosition(this UIElement that)
+        {
+            return new Vector2((int)Canvas.GetLeft(that), (int)Canvas.GetTop(that));
+        }
+    }
+}


### PR DESCRIPTION
Anno 1800's coordinate system is tilted by 45° with its origin being at the bottom. The X-axis goes from bottom to the right and the Y axis from bottom to left. WPF's coordinate system is not-titled and has its X-axis going towards the right and its Y-axis towards the bottom. Thus we need a conversion between the elements' positions within the editor to their actual coordinates in game.

Until now, the canvas of `MapView` was titled by -45°. Doing so introduces two problems:
1. (0,0) is located at the left corner
2. The Y-axis is flipped with respect to Anno 1800

To compensate for these differences, within `MapObject`, the objects' coordinates on the canvas are turned into Anno 1800 coordinates by flipping the Y-axis. Because flipping the axis moves the objects' anchor position from one corner to another, doing so requires knowledge about the objects' dimensions. Additionally, this conversion must take place whenever coordinates move from the UI layer to the map layer.


This PR introduces the following changes:

1. Tilt the MapView by -135°
This moves the coordinate system's origin to the bottom. Thus transformations do not need to account for the object's dimensions.

2. Flip X- and Y-axis during serialization
Tilting by 135° flips the X- and Y-axis compared to Anno 1800. To compensate we need to flip each object's coordinates during serialization. This can be done in one-line for all objects.