### PR TITLE
Automatically center offsets when going back to centered mode

### DIFF
--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml
@@ -93,27 +93,6 @@
 
                 <!-- Margin/Playable Area -->
                 <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" Margin="2,2,0,0" HorizontalAlignment="Left">
-                    <!-- Margin Offset Warning -->
-                    <emoji:TextBlock Text="&#x26a0;" FontSize="14" VerticalAlignment="Center" Margin="0,-4" Padding="0,0,0,4"
-                                     Visibility="{Binding NonCenteredMarginWarning, Mode=OneWay, Converter={StaticResource BoolToVisibility}}">
-                        <emoji:TextBlock.ToolTip>
-                            <TextBlock>
-                                The Margin mode is set to centered, but the current margin configuration is NOT centered!
-                                <LineBreak/>
-                                Editing the Margin now will remove the currently set Offsets.
-                            </TextBlock>
-                        </emoji:TextBlock.ToolTip>
-                    </emoji:TextBlock>
-                    
-                    <!-- Margin OK Info-->
-                    <emoji:TextBlock Text="&#x2714;" FontSize="14" VerticalAlignment="Center" Margin="0,-4" Padding="0,0,0,4"
-                                     Visibility="{Binding NonCenteredMarginWarning, Mode=OneWay, Converter={StaticResource BoolToVisibilityInverted}}">
-                        <emoji:TextBlock.ToolTip>
-                            <TextBlock>
-                                The Margin mode is either set to custom, or is set to centered, and there is no offset.
-                            </TextBlock>
-                        </emoji:TextBlock.ToolTip>
-                    </emoji:TextBlock>
                     
                     <!-- Margin Mode Toggle -->
                     <local:FancyToggle Label="Margin Mode:" OffText="Centered" OnText="Custom" 
@@ -125,7 +104,7 @@
 
 
                 <!-- Margin OK Info-->
-                <emoji:TextBlock Text="&#x26a0; Margin not centered! Going back to centered mode will reset your margins."
+                <emoji:TextBlock Text="&#x26a0; PlayableArea not centered! Going back to centered mode will reset offsets."
                                  MaxWidth="200"
                                  Grid.ColumnSpan="2"
                                  TextWrapping="Wrap"

--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml
@@ -52,6 +52,7 @@
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
 
                     <!-- Playable Area -->
                     <RowDefinition Height="auto" />
@@ -116,27 +117,44 @@
                     
                     <!-- Margin Mode Toggle -->
                     <local:FancyToggle Label="Margin Mode:" OffText="Centered" OnText="Custom" 
-                                       IsChecked="{Binding MarginMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                       IsChecked="{Binding MarginMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                       ValueChanged="FancyToggle_ValueChanged"/>
+
+                    
                 </StackPanel>
 
 
-                <TextBlock Grid.Row="4" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" Text="Playable Area:" />
-                <TextBlock Grid.Row="4" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" >
+                <!-- Margin OK Info-->
+                <emoji:TextBlock Text="&#x26a0; Margin not centered! Going back to centered mode will reset your margins."
+                                 MaxWidth="200"
+                                 Grid.ColumnSpan="2"
+                                 TextWrapping="Wrap"
+                                 HorizontalAlignment="Left"
+                                 Style="{StaticResource DefaultLabelStyle}"
+                                 Margin="2,0,2,2"
+                                 Grid.Row="4"
+                                 Visibility="{Binding NonCenteredMarginWarning, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisibility}}">
+                </emoji:TextBlock>
+
+
+
+                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" Text="Playable Area:" />
+                <TextBlock Grid.Row="5" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" >
                                 <Run Text="{Binding PlayableSize, Mode=OneWay}"/>
                                 <Run Text="x"/>
                                 <Run Text="{Binding PlayableSize, Mode=OneWay}"/>
                 </TextBlock>
 
                 <!-- Avg Margin -->
-                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Average Margin:" 
+                <TextBlock Grid.Row="6" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Average Margin:" 
                            Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}"/>
-                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Margin:" 
+                <TextBlock Grid.Row="6" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Margin:" 
                            Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityInverted}}"/>
-                <TextBlock Grid.Row="5" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
+                <TextBlock Grid.Row="6" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
                                 <Run Text="{Binding AverageMargin, Mode=OneWay}"/>
                 </TextBlock>
 
-                <Grid Grid.Row="6" Grid.ColumnSpan="2">
+                <Grid Grid.Row="7" Grid.ColumnSpan="2">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
@@ -154,7 +172,7 @@
                 </Grid>
                 
                 <!-- Offsets -->
-                <Grid Grid.Row="7" Grid.ColumnSpan="2" Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}">
+                <Grid Grid.Row="8" Grid.ColumnSpan="2" Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="auto"/>
                         <ColumnDefinition Width="*"/>

--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml
@@ -102,38 +102,23 @@
                     
                 </StackPanel>
 
-
-                <!-- Margin OK Info-->
-                <emoji:TextBlock Text="&#x26a0; PlayableArea not centered! Going back to centered mode will reset offsets."
-                                 MaxWidth="200"
-                                 Grid.ColumnSpan="2"
-                                 TextWrapping="Wrap"
-                                 HorizontalAlignment="Left"
-                                 Style="{StaticResource DefaultLabelStyle}"
-                                 Margin="2,0,2,2"
-                                 Grid.Row="4"
-                                 Visibility="{Binding NonCenteredMarginWarning, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisibility}}">
-                </emoji:TextBlock>
-
-
-
-                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" Text="Playable Area:" />
-                <TextBlock Grid.Row="5" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" >
+                <TextBlock Grid.Row="4" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" Text="Playable Area:" />
+                <TextBlock Grid.Row="4" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" >
                                 <Run Text="{Binding PlayableSize, Mode=OneWay}"/>
                                 <Run Text="x"/>
                                 <Run Text="{Binding PlayableSize, Mode=OneWay}"/>
                 </TextBlock>
 
                 <!-- Avg Margin -->
-                <TextBlock Grid.Row="6" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Average Margin:" 
+                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Average Margin:" 
                            Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}"/>
-                <TextBlock Grid.Row="6" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Margin:" 
+                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Margin:" 
                            Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityInverted}}"/>
-                <TextBlock Grid.Row="6" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
+                <TextBlock Grid.Row="5" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
                                 <Run Text="{Binding AverageMargin, Mode=OneWay}"/>
                 </TextBlock>
 
-                <Grid Grid.Row="7" Grid.ColumnSpan="2">
+                <Grid Grid.Row="6" Grid.ColumnSpan="2">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
@@ -151,7 +136,7 @@
                 </Grid>
                 
                 <!-- Offsets -->
-                <Grid Grid.Row="8" Grid.ColumnSpan="2" Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}">
+                <Grid Grid.Row="7" Grid.ColumnSpan="2" Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="auto"/>
                         <ColumnDefinition Width="*"/>
@@ -211,9 +196,22 @@
                         <TextBlock Grid.Column="2" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MaxOffset, Mode=OneWay}"/>
                     </Grid>
                 </Grid>
+                <!-- Margin OK Info-->
+                <emoji:TextBlock Text="&#x26a0; PlayableArea not centered! Going back to centered mode will reset offsets."
+                                 MaxWidth="200"
+                                 Grid.ColumnSpan="2"
+                                 TextWrapping="Wrap"
+                                 HorizontalAlignment="Left"
+                                 Style="{StaticResource DefaultLabelStyle}"
+                                 Margin="2,0,2,2"
+                                 Grid.Row="8"
+                                 Visibility="{Binding NonCenteredMarginWarning, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisibility}}">
+                </emoji:TextBlock>
+
 
             </Grid>
-            
+
+
         </Expander>
     </StackPanel>
 </UserControl>

--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml
@@ -198,7 +198,7 @@
                 </Grid>
                 <!-- Margin OK Info-->
                 <emoji:TextBlock Text="&#x26a0; PlayableArea not centered! Going back to centered mode will reset offsets."
-                                 MaxWidth="200"
+                                 MaxWidth="180"
                                  Grid.ColumnSpan="2"
                                  TextWrapping="Wrap"
                                  HorizontalAlignment="Left"

--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoMapEditor.MapTemplates;
+using AnnoMapEditor.UI.Models;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -32,6 +33,14 @@ namespace AnnoMapEditor.UI.Controls
             if (DataContext is Models.SessionPropertiesViewModel viewModel)
             {
                 viewModel.DragInProgress = true;
+            }
+        }
+
+        private void FancyToggle_ValueChanged(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is Models.SessionPropertiesViewModel viewModel && viewModel.IsMarginNonCentered)
+            {
+                viewModel.Center();
             }
         }
     }

--- a/AnnoMapEditor/UI/Models/SessionPropertiesViewModel.cs
+++ b/AnnoMapEditor/UI/Models/SessionPropertiesViewModel.cs
@@ -163,10 +163,10 @@ namespace AnnoMapEditor.UI.Models
         public bool NonCenteredMarginWarning
         {
             //For a warning when not all Margins are equal, but we are in MarginMode Centered
-            get => MarginMode == false && IsMarginNonCentered;
+            get => IsMarginNonCentered;
         }
 
-        private bool IsMarginNonCentered
+        public bool IsMarginNonCentered
         {
             get => OffsetY != 0 || OffsetX != 0;
         }
@@ -176,7 +176,7 @@ namespace AnnoMapEditor.UI.Models
             get => Math.Clamp(_offsetY, MinOffset, MaxOffset);
             set
             {
-                SetProperty(ref _offsetY, value);
+                SetProperty(ref _offsetY, value, new string[] { nameof(NonCenteredMarginWarning) });
                 ResizeSessionValues();
             }
         }
@@ -187,7 +187,7 @@ namespace AnnoMapEditor.UI.Models
             get => Math.Clamp(_offsetX, MinOffset, MaxOffset);
             set
             {
-                SetProperty(ref _offsetX, value);
+                SetProperty(ref _offsetX, value, new string[] { nameof(NonCenteredMarginWarning)});
                 ResizeSessionValues();
             }
         }
@@ -255,6 +255,12 @@ namespace AnnoMapEditor.UI.Models
         private void HandleSessionSizeCommitted(object? sender, EventArgs _)
         {
             UpdateMapSizeText();
+        }
+
+        public void Center()
+        { 
+            OffsetX= 0;
+            OffsetY=0;
         }
     }
 }


### PR DESCRIPTION
Currently if you are going back from custom to centered, the map will let you do it. 

When going back from Custom to center, the app now resets OffsetX and OffsetY to 0, so being in centered mode always operates on a centered map. 
If the map is not centered in custom mode, you get a warning that you should not go back to centered mode, but you can do so of course. 

![image](https://user-images.githubusercontent.com/51975164/209571860-1dce508b-5580-4719-829b-af7bdc96948b.png)
