### PR TITLE
Split Regions and Pools

### DIFF
--- a/AnnoMapEditor/MapTemplates/FilePathRange.cs
+++ b/AnnoMapEditor/MapTemplates/FilePathRange.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+
+namespace AnnoMapEditor.MapTemplates
+{
+    public struct FilePathRange
+    {
+        public string filePath;
+        public int size;
+        public int[] ids;
+
+        public string GetPath(int i)
+        {
+            return string.Format(filePath, string.Format("{0:00}", ids[i]));
+        }
+
+        public FilePathRange(string filePath, int start, int count)
+        {
+            this.filePath = filePath;
+            this.size = count;
+            this.ids = Enumerable.Range(start, count).ToArray();
+        }
+
+        public FilePathRange(string filePath, int[] ids)
+        {
+            this.filePath = filePath;
+            this.size = ids.Length;
+            this.ids = ids;
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Island.cs
+++ b/AnnoMapEditor/MapTemplates/Island.cs
@@ -1,6 +1,5 @@
 ﻿using Anno.FileDBModels.Anno1800.MapTemplate;
 using AnnoMapEditor.MapTemplates.Serializing;
-using AnnoMapEditor.UI;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -292,7 +291,7 @@ namespace AnnoMapEditor.MapTemplates
 
             if (mapPath == null)
             {
-                mapPath = region.GetRandomIslandPath(Size);
+                mapPath = Pool.GetRandomIslandPath(region, Size);
                 Rotation = rnd.Next(0, 3);
             }
 

--- a/AnnoMapEditor/MapTemplates/Pool.cs
+++ b/AnnoMapEditor/MapTemplates/Pool.cs
@@ -1,14 +1,100 @@
-﻿namespace AnnoMapEditor.MapTemplates
+﻿using System;
+using System.Collections.Generic;
+
+namespace AnnoMapEditor.MapTemplates
 {
     public class Pool
     {
-        public FilePathRange[] paths { get; init; }
-        public int size
+        public static readonly IEnumerable<Pool> All = new List<Pool>()
+        {
+            // Moderate
+            new(Region.Moderate, IslandSize.Small,
+                "data/sessions/islands/pool/moderate/moderate_s_{0}/moderate_s_{0}.a7m", 12
+                ),
+            new(Region.Moderate, IslandSize.Medium,
+                "data/sessions/islands/pool/moderate/moderate_m_{0}/moderate_m_{0}.a7m", 9
+                ),
+            new(Region.Moderate, IslandSize.Large,
+                new FilePathRange[]
+                {
+                    new FilePathRange("data/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 1, 14),
+                    new FilePathRange("data/sessions/islands/pool/moderate/community_island/community_island.a7m", 1, 1)
+                }),
+            
+             // NewWorld
+            new(Region.NewWorld, IslandSize.Small,
+                new FilePathRange[]
+                {
+                    new FilePathRange("data/sessions/islands/pool/colony01/colony01_s_{0}/colony01_s_{0}.a7m", 1, 4),
+                    new FilePathRange("data/dlc12/sessions/islands/pool/colony01/colony01_s_{0}/colony01_s_{0}.a7m", 5, 3)
+                }),
+            new(Region.NewWorld, IslandSize.Medium,
+                new FilePathRange[]
+                {
+                    new FilePathRange("data/sessions/islands/pool/colony01/colony01_m_{0}/colony01_m_{0}.a7m", 1, 6),
+                    new FilePathRange("data/dlc12/sessions/islands/pool/colony01/colony01_m_{0}/colony01_m_{0}.a7m", 7, 3)
+                }),
+            new(Region.NewWorld, IslandSize.Large,
+                new FilePathRange[]
+                {
+                    new FilePathRange("data/sessions/islands/pool/colony01/colony01_l_{0}/colony01_l_{0}.a7m", 1, 5),
+                    new FilePathRange("data/dlc12/sessions/islands/pool/colony01/colony01_l_{0}/colony01_l_{0}.a7m", 6, 3),
+
+                }),
+
+            // Arctic
+            new(Region.Arctic, IslandSize.Small,  "data/dlc03/sessions/islands/pool/colony03_a01_{0}/colony03_a01_{0}.a7m", 8),
+            new(Region.Arctic, IslandSize.Medium, "data/dlc03/sessions/islands/pool/colony03_a02_{0}/colony03_a02_{0}.a7m", 4),
+            new(Region.Arctic, IslandSize.Large,  "data/dlc03/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 14),
+
+            // Enbesa
+            new(Region.Enbesa, IslandSize.Small,  "data/dlc06/sessions/islands/pool/colony02_s_{0}/colony02_s_{0}.a7m", new int[] { 1, 2, 3, 5 }),
+            new(Region.Enbesa, IslandSize.Medium, "data/dlc06/sessions/islands/pool/colony02_m_{0}/colony02_m_{0}.a7m", new int[] { 2, 4, 5, 9 }),
+            new(Region.Enbesa, IslandSize.Large,  "data/dlc06/sessions/islands/pool/colony02_l_{0}/colony02_l_{0}.a7m", new int[] { 1, 3, 5, 6 }),
+        };
+
+        private static readonly Dictionary<(Region, IslandSize), Pool> _poolsMap;
+        static Pool() {
+            _poolsMap = new();
+            foreach (Pool pool in All)
+            {
+                _poolsMap[(pool.Region, pool.IslandSize)] = pool;
+            }
+        }
+
+
+        public readonly Region Region;
+
+        public readonly IslandSize IslandSize;
+
+
+        public static Pool GetPool(Region region, IslandSize islandSize)
+        {
+            return _poolsMap[(region, islandSize)];
+        }
+
+        public static string GetRandomIslandPath(Region region, IslandSize islandSize)
+        {
+            // use a random Small island for IslandSize.Default
+            if (islandSize == IslandSize.Default)
+                islandSize = IslandSize.Small;
+
+            Pool pool = GetPool(region, islandSize);
+            int index = Random.Shared.Next(1, pool.Size);
+
+            string path = pool.GetPath(index);
+            return path;
+        }
+
+
+        private readonly FilePathRange[] _paths;
+
+        public int Size
         {
             get
             {
                 int sum = 0;
-                foreach(var path in paths)
+                foreach (var path in _paths)
                 {
                     sum += path.size;
                 }
@@ -16,39 +102,43 @@
             }
         }
 
+
         public string GetPath(int i)
         {
             int rangeIdx = 0;
-            FilePathRange range = paths[rangeIdx];
+            FilePathRange range = _paths[rangeIdx];
             int skipped = 0;
             while(skipped + range.size <= i)
             {
                 skipped += range.size;
-                range = paths[++rangeIdx];
+                range = _paths[++rangeIdx];
             }
 
             return range.GetPath(i - skipped);
         }
 
-        public Pool(string filePath, int size)
+
+        public Pool(Region region, IslandSize islandSize, FilePathRange[] paths)
         {
-            this.paths = new FilePathRange[]
+            Region = region;
+            IslandSize = islandSize;
+            _paths = paths;
+        }
+
+        public Pool(Region region, IslandSize islandSize, string filePath, int size)
+            : this(region, islandSize, new FilePathRange[]
             {
                 new FilePathRange(filePath, 1, size)
-            };
+            })
+        {
         }
 
-        public Pool(string filePath, int[] ids)
-        {
-            this.paths = new FilePathRange[]
+        public Pool(Region region, IslandSize islandSize, string filePath, int[] ids)
+            : this(region, islandSize, new FilePathRange[]
             {
                 new FilePathRange(filePath, ids)
-            };
-        }
-
-        public Pool(FilePathRange[] paths)
+            })
         {
-            this.paths = paths;
         }
     }
 }

--- a/AnnoMapEditor/MapTemplates/Pool.cs
+++ b/AnnoMapEditor/MapTemplates/Pool.cs
@@ -1,0 +1,54 @@
+﻿namespace AnnoMapEditor.MapTemplates
+{
+    public class Pool
+    {
+        public FilePathRange[] paths { get; init; }
+        public int size
+        {
+            get
+            {
+                int sum = 0;
+                foreach(var path in paths)
+                {
+                    sum += path.size;
+                }
+                return sum;
+            }
+        }
+
+        public string GetPath(int i)
+        {
+            int rangeIdx = 0;
+            FilePathRange range = paths[rangeIdx];
+            int skipped = 0;
+            while(skipped + range.size <= i)
+            {
+                skipped += range.size;
+                range = paths[++rangeIdx];
+            }
+
+            return range.GetPath(i - skipped);
+        }
+
+        public Pool(string filePath, int size)
+        {
+            this.paths = new FilePathRange[]
+            {
+                new FilePathRange(filePath, 1, size)
+            };
+        }
+
+        public Pool(string filePath, int[] ids)
+        {
+            this.paths = new FilePathRange[]
+            {
+                new FilePathRange(filePath, ids)
+            };
+        }
+
+        public Pool(FilePathRange[] paths)
+        {
+            this.paths = paths;
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Region.cs
+++ b/AnnoMapEditor/MapTemplates/Region.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AnnoMapEditor.MapTemplates
 {
@@ -14,68 +12,23 @@ namespace AnnoMapEditor.MapTemplates
         public static readonly Region Moderate = new("Moderate", "Moderate", "Moderate_01_day_night", allowModding:true, "moderate",
             new[] { "ll", "lm", "ls", "ml", "mm", "ms", "sl", "sm", "ss" },
             new[] { "01", "02" },
-            usesAllSizeIndices:false, hasMapExtension:false,
-            new()
-            {
-                [IslandSize.Small] = new Pool("data/sessions/islands/pool/moderate/moderate_s_{0}/moderate_s_{0}.a7m", 12),
-                [IslandSize.Medium] = new Pool("data/sessions/islands/pool/moderate/moderate_m_{0}/moderate_m_{0}.a7m", 9),
-                [IslandSize.Large] = new Pool(
-                    new FilePathRange[]
-                    {
-                        new FilePathRange("data/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 1, 14),
-                        new FilePathRange("data/sessions/islands/pool/moderate/community_island/community_island.a7m", 1, 1)
-                    })
-            });
+            usesAllSizeIndices:false, hasMapExtension:false);
 
         public static readonly Region NewWorld = new("NewWorld", "New World", "south_america_caribic_01", allowModding: true, "colony01", 
             new[] { "s", "m", "l"},
             new[] { "01", "02", "03" },
-            usesAllSizeIndices: true, hasMapExtension: true,
-            new()
-            {
-                [IslandSize.Small] = new Pool(
-                    new FilePathRange[]
-                    {
-                        new FilePathRange("data/sessions/islands/pool/colony01/colony01_s_{0}/colony01_s_{0}.a7m", 1, 4),
-                        new FilePathRange("data/dlc12/sessions/islands/pool/colony01/colony01_s_{0}/colony01_s_{0}.a7m", 5, 3)
-                    }),
-                [IslandSize.Medium] = new Pool(
-                    new FilePathRange[]
-                    {
-                        new FilePathRange("data/sessions/islands/pool/colony01/colony01_m_{0}/colony01_m_{0}.a7m", 1, 6),
-                        new FilePathRange("data/dlc12/sessions/islands/pool/colony01/colony01_m_{0}/colony01_m_{0}.a7m", 7, 3)
-                    }),
-                [IslandSize.Large] = new Pool(
-                    new FilePathRange[]
-                    {
-                        new FilePathRange("data/sessions/islands/pool/colony01/colony01_l_{0}/colony01_l_{0}.a7m", 1, 5),
-                        new FilePathRange("data/dlc12/sessions/islands/pool/colony01/colony01_l_{0}/colony01_l_{0}.a7m", 6, 3),
-
-                    })
-            });
+            usesAllSizeIndices: true, hasMapExtension: true);
 
         //poolFolderName is manually selected, the game files don't have a special one for the arctic as it only has one map
         public static readonly Region Arctic = new("Arctic", "Arctic", "DLC03_01", allowModding: false, poolFolderName:"colony03",
             new[] { "sp" },
             new[] { "" },
-            usesAllSizeIndices: true, hasMapExtension: false,
-            new()
-            {
-                [IslandSize.Small] = new Pool("data/dlc03/sessions/islands/pool/colony03_a01_{0}/colony03_a01_{0}.a7m", 8),
-                [IslandSize.Medium] = new Pool("data/dlc03/sessions/islands/pool/colony03_a02_{0}/colony03_a02_{0}.a7m", 4),
-                [IslandSize.Large] = new Pool("data/dlc03/sessions/islands/pool/moderate/moderate_l_{0}/moderate_l_{0}.a7m", 14)
-            });
+            usesAllSizeIndices: true, hasMapExtension: false);
 
         public static readonly Region Enbesa = new("Enbesa", "Enbesa", "Colony_02", allowModding: false, "land_of_lions",
             new[] { "01" },
             new[] { "", "mp" },
-            usesAllSizeIndices: true, hasMapExtension: false,
-            new()
-            {
-                [IslandSize.Small] = new Pool("data/dlc06/sessions/islands/pool/colony02_s_{0}/colony02_s_{0}.a7m", new int[] { 1, 2, 3, 5 }),
-                [IslandSize.Medium] = new Pool("data/dlc06/sessions/islands/pool/colony02_m_{0}/colony02_m_{0}.a7m", new int[] { 2, 4, 5, 9 }),
-                [IslandSize.Large] = new Pool("data/dlc06/sessions/islands/pool/colony02_l_{0}/colony02_l_{0}.a7m", new int[] { 1, 3, 5, 6 })
-            });
+            usesAllSizeIndices: true, hasMapExtension: false);
 
         public static readonly Region[] All = new Region[] { Moderate, NewWorld, Arctic, Enbesa };
         #endregion
@@ -91,16 +44,11 @@ namespace AnnoMapEditor.MapTemplates
         public bool UsesAllSizeIndices { get; init; }
         public bool HasMapExtension { get; init; }
 
-        private static readonly Random rnd = new((int)DateTime.Now.Ticks);
-
         private readonly string value;
 
 
-        public Dictionary<IslandSize, Pool> PoolIslands { get; private init; }
-
-
         private Region(string type, string name, string ambientName, bool allowModding, string poolFolderName, 
-            string[] mapSizes, string[] sizeIndices, bool usesAllSizeIndices, bool hasMapExtension, Dictionary<IslandSize, Pool> poolIslands)
+            string[] mapSizes, string[] sizeIndices, bool usesAllSizeIndices, bool hasMapExtension)
         {
             value = type;
             Name = name;
@@ -113,20 +61,6 @@ namespace AnnoMapEditor.MapTemplates
 
             UsesAllSizeIndices = usesAllSizeIndices;
             HasMapExtension = hasMapExtension;
-
-            PoolIslands = poolIslands;
-        }
-
-        public string GetRandomIslandPath(IslandSize size)
-        {
-            // use a random Small island for IslandSize.Default
-            if (size == IslandSize.Default)
-                size = IslandSize.Small;
-
-            int index = rnd.Next(1, PoolIslands[size].size);
-
-            string path = PoolIslands[size].GetPath(index);
-            return path;
         }
 
         public IEnumerable<string> GetAllSizeCombinations()

--- a/AnnoMapEditor/MapTemplates/Region.cs
+++ b/AnnoMapEditor/MapTemplates/Region.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace AnnoMapEditor.MapTemplates
 {
-    public struct Region
+    public partial struct Region
     {
         #region Region enums
         //Technically, Cape Trelawney is in Moderate Region but has ambientName "Moderate_01_day_night_st",
@@ -96,86 +95,9 @@ namespace AnnoMapEditor.MapTemplates
 
         private readonly string value;
 
-        #region Pool Islands
-        public struct Pool
-        {
-            public FilePathRange[] paths { get; init; }
-            public int size
-            {
-                get
-                {
-                    int sum = 0;
-                    foreach(var path in paths)
-                    {
-                        sum += path.size;
-                    }
-                    return sum;
-                }
-            }
 
-            public string GetPath(int i)
-            {
-                int rangeIdx = 0;
-                FilePathRange range = paths[rangeIdx];
-                int skipped = 0;
-                while(skipped + range.size <= i)
-                {
-                    skipped += range.size;
-                    range = paths[++rangeIdx];
-                }
-
-                return range.GetPath(i - skipped);
-            }
-
-            public Pool(string filePath, int size)
-            {
-                this.paths = new FilePathRange[]
-                {
-                    new FilePathRange(filePath, 1, size)
-                };
-            }
-
-            public Pool(string filePath, int[] ids)
-            {
-                this.paths = new FilePathRange[]
-                {
-                    new FilePathRange(filePath, ids)
-                };
-            }
-
-            public Pool(FilePathRange[] paths)
-            {
-                this.paths = paths;
-            }
-        }
-
-        public struct FilePathRange
-        {
-            public string filePath;
-            public int size;
-            public int[] ids;
-
-            public string GetPath(int i)
-            {
-                return string.Format(filePath, string.Format("{0:00}", ids[i]));
-            }
-
-            public FilePathRange(string filePath, int start, int count)
-            {
-                this.filePath = filePath;
-                this.size = count;
-                this.ids = Enumerable.Range(start, count).ToArray();
-            }
-
-            public FilePathRange(string filePath, int[] ids)
-            {
-                this.filePath = filePath;
-                this.size = ids.Length;
-                this.ids = ids;
-            }
-        }
         public Dictionary<IslandSize, Pool> PoolIslands { get; private init; }
-        #endregion
+
 
         private Region(string type, string name, string ambientName, bool allowModding, string poolFolderName, 
             string[] mapSizes, string[] sizeIndices, bool usesAllSizeIndices, bool hasMapExtension, Dictionary<IslandSize, Pool> poolIslands)

--- a/AnnoMapEditor/UI/Models/SessionChecker.cs
+++ b/AnnoMapEditor/UI/Models/SessionChecker.cs
@@ -75,18 +75,22 @@ namespace AnnoMapEditor.UI.Models
                 // remove all but one pirate island from pool counter
                 pools[0] -= pirateCount - 1;
             }
-            
-            if (pools[0] > session.Region.PoolIslands[IslandSize.Small].size)
+
+            int maxSmallPoolSize  = Pool.GetPool(session.Region, IslandSize.Small).Size;
+            int maxMediumPoolSize = Pool.GetPool(session.Region, IslandSize.Medium).Size;
+            int maxLargePoolSize  = Pool.GetPool(session.Region, IslandSize.Large).Size;
+
+            if (pools[0] > maxSmallPoolSize)
             {
-                Status = $"⚠ Too many small pool islands.\nOnly the first {session.Region.PoolIslands[IslandSize.Small].size} islands will be loaded.\nThird party and pirate islands\nare considered small pool islands if deactivated.";
+                Status = $"⚠ Too many small pool islands.\nOnly the first {maxSmallPoolSize} islands will be loaded.\nThird party and pirate islands\nare considered small pool islands if deactivated.";
             }
-            else if (pools[1] > session.Region.PoolIslands[IslandSize.Medium].size)
+            else if (pools[1] > maxMediumPoolSize)
             {
-                Status = $"⚠ Too many medium pool islands.\nOnly the first {session.Region.PoolIslands[IslandSize.Medium].size} islands will be loaded.";
+                Status = $"⚠ Too many medium pool islands.\nOnly the first {maxMediumPoolSize} islands will be loaded.";
             }
-            else if (pools[2] > session.Region.PoolIslands[IslandSize.Large].size)
+            else if (pools[2] > maxLargePoolSize)
             {
-                Status = $"⚠ Too many large pool islands.\nOnly the first {session.Region.PoolIslands[IslandSize.Large].size} islands will be loaded.";
+                Status = $"⚠ Too many large pool islands.\nOnly the first {maxLargePoolSize} islands will be loaded.";
             }
             else if (pools[0] < 0)
             {


### PR DESCRIPTION
> **Based on #30** 
> I will rebase this branch onto main once #30 has been merged.

Currently all instances of `Pool` are created in the static initializers of `Region`. This introduces a hard coupling, where any call to the class `Region` inadvertently loads the Pools. In the future Pools shall contain a list of IslandTemplates. They are dependent on the loaded `IDataArchive`, which does not exist statically. Thus the dependency between the two classes must be removed.

This PR moves `Pool` initialization to the `Pool` class. Additionally, regions no longer have a member referencing their Pools. Instead, they get them at runtime via `Pool.GetPool(...)`. These changes remove the dependency mentioned above and serve as preparation to load Pools from the `IDataArchive` directly instead of using hardcoded lists.