### PR TITLE
Added preliminary models for MapElements.

### DIFF
--- a/AnnoMapEditor/MapTemplates/Models/Elements/FixedIsland.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Elements/FixedIsland.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Models.Elements
+{
+    public class FixedIsland : IslandElement
+    {
+        public int Rotation
+        {
+            get => _rotation;
+            set
+            {
+                if (value != _rotation)
+                {
+                    _rotation = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        private int _rotation = 0;
+
+        public string MapFilePath
+        {
+            get => _mapFilePath;
+            set
+            {
+                if (value != _mapFilePath)
+                {
+                    _mapFilePath = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        private string _mapFilePath;
+
+
+        public FixedIsland(string mapFilePath, int sizeInTiles)
+        {
+            _mapFilePath = mapFilePath;
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Models/Elements/IslandElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Elements/IslandElement.cs
@@ -1,0 +1,35 @@
+﻿using Anno.FileDBModels.Anno1800.MapTemplate;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Models.Elements
+{
+    public abstract class IslandElement : MapElement
+    {
+        public string? Label
+        {
+            get => _label;
+            set
+            {
+                if (value != _label)
+                {
+                    _label = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        private string? _label;
+
+
+        protected override void ToTemplate(TemplateElement result)
+        {
+            if (Label != null)
+            {
+                result.Element!.IslandLabel = Label;
+            }
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Models/Elements/MapElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Elements/MapElement.cs
@@ -1,0 +1,42 @@
+﻿using Anno.FileDBModels.Anno1800.MapTemplate;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Models.Elements
+{
+    public abstract class MapElement : ObservableBase
+    {
+        public Vector2 Position
+        {
+            get => _position;
+            set
+            {
+                if (value != _position)
+                {
+                    _position = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        private Vector2 _position = Vector2.Zero;
+
+
+        public TemplateElement ToTemplate()
+        {
+            TemplateElement result = new();
+
+            // set common properties
+            result.Element = new();
+            result.Element.Position = new int[] { Position.Y, Position.X };
+
+            ToTemplate(result);
+
+            return result;
+        }
+
+        protected abstract void ToTemplate(TemplateElement result);
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Models/Elements/RandomIsland.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Elements/RandomIsland.cs
@@ -1,0 +1,47 @@
+﻿using Anno.FileDBModels.Anno1800.MapTemplate;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Models.Elements
+{
+    public class RandomIsland : IslandElement
+    {
+        public IslandSize Size
+        {
+            get => _size;
+            set
+            {
+                if (value != _size)
+                {
+                    _size = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        private IslandSize _size;
+
+
+        public RandomIsland(IslandSize size)
+        {
+            _size = size;
+        }
+
+
+        protected override void ToTemplate(TemplateElement result)
+        {
+            base.ToTemplate(result);
+
+            result.Element!.Size = Size.ElementValue;
+            // TODO: Comments! What do Difficulty and Config do? Why do we set them to these values?
+            result.Element!.Difficulty = new();
+            result.Element!.Config = new()
+            {
+                Type = new() { id = null },
+                Difficulty = new()
+            };
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/Models/Elements/StartingSpot.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Elements/StartingSpot.cs
@@ -1,0 +1,27 @@
+﻿using Anno.FileDBModels.Anno1800.MapTemplate;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.MapTemplates.Models.Elements
+{
+    public class StartingSpot : MapElement
+    {
+        public int Index { get; }
+
+
+        public StartingSpot(int index, Vector2 position)
+        {
+            Index = index;
+            Position = position;
+        }
+
+
+        protected override void ToTemplate(TemplateElement result)
+        {
+            result.ElementType = (short) MapElementType.StartingSpot;
+        }
+    }
+}

--- a/AnnoMapEditor/MapTemplates/ObservableBase.cs
+++ b/AnnoMapEditor/MapTemplates/ObservableBase.cs
@@ -6,20 +6,6 @@ namespace AnnoMapEditor.MapTemplates
     public class ObservableBase : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler? PropertyChanged = delegate { };
-        protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        protected void SetProperty<T>(ref T property, T value, string[]? dependingPropertyNames = null, [CallerMemberName] string propertyName = "")
-        {
-            if (property is null && value is null)
-                return;
-
-            if (!(property?.Equals(value) ?? false))
-            {
-                property = value;
-                OnPropertyChanged(propertyName);
-                if (dependingPropertyNames is not null)
-                    foreach (var name in dependingPropertyNames)
-                        OnPropertyChanged(name);
-            }
-        }
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }


### PR DESCRIPTION
Maps contain three different kinds of elements: Starting spots, fixed islands and random islands based on island pools. Currently, all of those elements are represented using the same class `Island.cs`. Similarly, the same control `MapObject.xaml` is used for all three. Given that the three elements have different properties and behaviours, having them share the same class complicates matters a lot.

This PR serves to separate the different elements into different classes, whilst using common base classes whenever useful. It has the following goals:

1. [ ] Create separate models: `MapElement`, `StartingSpot`, `IslandElement`, `FixedIsland`, `RandomIsland`
2. [ ] Create separate controls: `MapElementControl`, `StartingSpotControl`, `FixedIslandControl`, `RandomIslandControl`
3. [ ] Create a new control for add buttons on the `MapView`.
4. [ ] Refactor existing codebase to use the new models and controls.