### PR TITLE
Add a DDSConverter based on pfim

### DIFF
--- a/AnnoMapEditor/AnnoMapEditor.csproj
+++ b/AnnoMapEditor/AnnoMapEditor.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
+    <PackageReference Include="Pfim" Version="0.11.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
 

--- a/AnnoMapEditor/UI/Converters/DDSImageConverter.cs
+++ b/AnnoMapEditor/UI/Converters/DDSImageConverter.cs
@@ -1,0 +1,96 @@
+﻿using AnnoMapEditor.Utilities;
+using Pfim;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+using System.Windows.Media;
+using System.Text.RegularExpressions;
+using System.Linq.Expressions;
+
+namespace AnnoMapEditor.UI.Converters
+{
+    [ValueConversion(typeof(IImage), typeof(ImageSource))]
+    public class DDSImageConverter : IValueConverter
+    {
+        static string parameterregex = @"\b[0-9]+x[0-9]+\b";
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not IImage image)
+                return new Image();
+
+            Point size;
+            bool UseMipmaps = false;
+            if (parameter is string parameter_str && Regex.IsMatch(parameter_str, parameterregex))
+            {
+                var desired_size = parameter_str.Split("x");
+                if (long.TryParse(desired_size[0], out var x) && long.TryParse(desired_size[1], out var y))
+                {
+                    size = new Point(x, y);
+                    UseMipmaps = true;
+                }
+            }
+            var wpfimg = UseMipmaps ? WpfImageMipmapped(image, size) : WpfImage(image);
+            return wpfimg;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static ImageSource WpfImage(IImage image)
+        {
+            var pinnedArray = GCHandle.Alloc(image.Data, GCHandleType.Pinned);
+            var addr = pinnedArray.AddrOfPinnedObject();
+            var bsource = BitmapSource.Create(image.Width, image.Height, 96.0, 96.0,
+                PixelFormat(image), null, addr, image.DataLen, image.Stride);
+
+            return bsource;
+        }
+
+        private static ImageSource WpfImageMipmapped(IImage image, Point size)
+        {
+            var pinnedArray = GCHandle.Alloc(image.Data, GCHandleType.Pinned);
+            var addr = pinnedArray.AddrOfPinnedObject();
+
+            var mip = image.MipMaps.Where(x => x.Height >= size.X && x.Width >= size.Y).LastOrDefault();
+            if (mip is null)
+                return WpfImage(image);
+
+            var mipAddr = addr + mip.DataOffset;
+            var mipSource = BitmapSource.Create(mip.Width, mip.Height, 96.0, 96.0,
+                PixelFormat(image), null, mipAddr, mip.DataLen, mip.Stride);
+
+            return mipSource;
+        }
+
+        private static PixelFormat PixelFormat(IImage image)
+        {
+            switch (image.Format)
+            {
+                case ImageFormat.Rgb24:
+                    return PixelFormats.Bgr24;
+                case ImageFormat.Rgba32:
+                    return PixelFormats.Bgra32;
+                case ImageFormat.Rgb8:
+                    return PixelFormats.Gray8;
+                case ImageFormat.R5g5b5a1:
+                case ImageFormat.R5g5b5:
+                    return PixelFormats.Bgr555;
+                case ImageFormat.R5g6b5:
+                    return PixelFormats.Bgr565;
+                default:
+                    throw new Exception($"Unable to convert {image.Format} to WPF PixelFormat");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Based on https://github.com/nickbabcock/Pfim I added a DDSImageConverter that converts a `Pfim.IImage` to Wpf's `ImageSource`

## WPF

```Xaml
<ImageBrush ImageSource="{Binding TestImage, Converter={StaticResource ddsImage}, UpdateSourceTrigger=PropertyChanged}"/>
```

## The ViewModel

```Csharp
IImage TestImage { get; set; }
//later on setting the image
TestImage = Pfimage.FromStream(Settings.DataArchive.OpenRead("data/ui/2kimages/main/3dicons/icon_bus_stop_0.dds"));
```

## Using Mipmapping
To use the correct mipmap, one can specify a desired size for the image output formatted like `64x64` as ConverterParameter on the Binding. Ideally, that is the same size the image will be displayed as. 

```Xaml
<ImageBrush ImageSource="{Binding TestImage, Converter={StaticResource ddsImage}, UpdateSourceTrigger=PropertyChanged, ConverterParameter=46x46}"/>
```