### PR TITLE
Fix UnitTests when Game Files are not available

### DIFF
--- a/AnnoMapEditor.Tests/RoundTrip.cs
+++ b/AnnoMapEditor.Tests/RoundTrip.cs
@@ -7,7 +7,7 @@ namespace AnnoMapEditor.Tests
 {
     public class RoundTrip
     {
-        [Theory]
+        [TheoryWithGameFiles]
         [InlineData("./TestData/moderate_c_01.xml")]
         [InlineData("./TestData/campaign_chapter03_colony01.xml")]
         [InlineData("./TestData/moderate_islandarc_ss_01.xml")]

--- a/AnnoMapEditor.Tests/Utils/TheoryWithGameFilesAttribute.cs
+++ b/AnnoMapEditor.Tests/Utils/TheoryWithGameFilesAttribute.cs
@@ -1,0 +1,23 @@
+﻿namespace AnnoMapEditor.Tests.Utils
+{
+    internal class TheoryWithGameFilesAttribute : TheoryAttribute
+    {
+        /// <summary>
+        /// This Theory will be skipped if the game files are not automatically found by the App Settings.
+        /// </summary>
+        public TheoryWithGameFilesAttribute()
+        {
+            //Use a timer to show us how long we had to wait until we knew that we weren't gonna run this theory :D
+            System.Diagnostics.Stopwatch waitTimer = new ();
+            waitTimer.Start();
+            Utilities.Settings.Instance.WaitForLoadingBlocking();
+            waitTimer.Stop();
+
+            if (!Utilities.Settings.Instance.IsValidDataPath)
+            {
+                Skip = "The curring test environment has not detected the game files required for this unit test. " +
+                    $"Waited {waitTimer.ElapsedMilliseconds}ms for this information...";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some UnitTests (the RoundTrip Tests) require the game files to be present on the system. This is not the case for some environments (eg. CI builds). These tests are now skipped when the game files are not found.

(This also causes changes in the details of how the Settings class is initialized, though the previous behaviour should be unchanged.)