### PR TITLE
UI Cleanup le second

### DIFF
--- a/AnnoMapEditor/MapTemplates/Models/FixedIslandElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/FixedIslandElement.cs
@@ -37,7 +37,11 @@ namespace AnnoMapEditor.MapTemplates.Models
         public byte? Rotation
         {
             get => _rotation;
-            set => SetProperty(ref _rotation, value != null ? (byte)(value % 4) : null);
+            set 
+            {
+                SetProperty(ref _rotation, value != null ? (byte)(value % 4) : null);
+                SetProperty(ref _randomizeRotation, value == null);
+            }
         }
         private byte? _rotation;
 

--- a/AnnoMapEditor/UI/Controls/IslandProperties/FixedIslandProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/IslandProperties/FixedIslandProperties.xaml
@@ -18,7 +18,7 @@
                 <ResourceDictionary>
                     <converters:ObjectToVisibility x:Key="CollapsedOnNull" />
                     <converters:BoolToVisibility x:Key="VisibleOnFalse" OnTrue="Collapsed" OnFalse="Visible" />
-                    <converters:BooleaNotConverter x:Key="booleanNot" />
+                    <converters:BooleaNotConverter x:Key="BooleanNot" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -44,6 +44,7 @@
                    Style="{StaticResource SubHeaderLabelStyle}"/>
         <local:FancyToggle Label="Randomize"
                            OnText="Yes" OffText="No"
+                           IsEnabled="{Binding IsContinentalIsland, Converter={StaticResource BooleanNot}}"
                            IsChecked="{Binding FixedIsland.RandomizeRotation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         <Grid>
             <Grid.ColumnDefinitions>

--- a/AnnoMapEditor/UI/Controls/IslandProperties/FixedIslandPropertiesViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/IslandProperties/FixedIslandPropertiesViewModel.cs
@@ -2,6 +2,7 @@
 using AnnoMapEditor.MapTemplates.Models;
 using AnnoMapEditor.Utilities;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace AnnoMapEditor.UI.Controls.IslandProperties
 {
@@ -11,10 +12,13 @@ namespace AnnoMapEditor.UI.Controls.IslandProperties
 
         public ObservableCollection<IslandType> IslandTypeItems { get; } = new();
 
+        public bool IsContinentalIsland { get; init; }
+
 
         public FixedIslandPropertiesViewModel(FixedIslandElement fixedIslands)
         {
             FixedIsland = fixedIslands;
+            IsContinentalIsland = FixedIsland.IslandAsset.IslandSize.FirstOrDefault() == IslandSize.Continental;
 
             IslandTypeItems.AddRange(FixedIsland.IslandAsset.IslandType);
         }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -1,4 +1,7 @@
-﻿using AnnoMapEditor.MapTemplates.Models;
+﻿using AnnoMapEditor.MapTemplates.Enums;
+using AnnoMapEditor.MapTemplates.Models;
+using AnnoMapEditor.Utilities;
+using System.Linq;
 using System.Windows.Media.Imaging;
 
 namespace AnnoMapEditor.UI.Controls.MapTemplates
@@ -18,13 +21,17 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public override bool RandomizeRotation => _fixedIsland.RandomizeRotation;
 
+        private readonly bool _isContinentalIsland;
+
 
         public FixedIslandViewModel(Session session, FixedIslandElement fixedIsland) 
             : base(session, fixedIsland)
         {
             _fixedIsland = fixedIsland;
+            _isContinentalIsland = _fixedIsland.IslandAsset.IslandSize.FirstOrDefault() == IslandSize.Continental;
 
             UpdateThumbnailRotation();
+            SnapContinentalIsland();
 
             fixedIsland.PropertyChanged += FixedIsland_PropertyChanged;
         }
@@ -48,6 +55,57 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             _thumbnailRotation = (_fixedIsland.Rotation - 1) * -90;
 
             OnPropertyChanged(nameof(ThumbnailRotation));
+        }
+
+
+        public override void OnDragged(Vector2 newPosition)
+        {
+            base.OnDragged(newPosition);
+            SnapContinentalIsland();
+        }
+
+        // Rotates and snaps continental islands to the corners of the map.
+        // If a continental island is placed elswhere, it would result in graphical glitches.
+        private void SnapContinentalIsland()
+        {
+            if (!IsOutOfBounds && _isContinentalIsland)
+            {
+                Vector2 islandCenter = _fixedIsland.Position;
+                Vector2 mapCenterOffset = new((_session.Size.X - SizeInTiles) / 2, (_session.Size.Y - SizeInTiles) / 2);
+
+                if (islandCenter.X <= mapCenterOffset.X)
+                {
+                    // bottom
+                    if (islandCenter.Y <= mapCenterOffset.Y)
+                    {
+                        _fixedIsland.Rotation = 3;
+                        _fixedIsland.Position = new(0, 0);
+                    }
+
+                    // right
+                    else
+                    {
+                        _fixedIsland.Rotation = 0;
+                        _fixedIsland.Position = new(0, _session.Size.Y - SizeInTiles);
+                    }
+                }
+                else
+                {
+                    // left
+                    if (islandCenter.Y <= mapCenterOffset.Y)
+                    {
+                        _fixedIsland.Rotation = 2;
+                        _fixedIsland.Position = new(_session.Size.X - SizeInTiles, 0);
+                    }
+
+                    // top
+                    else
+                    {
+                        _fixedIsland.Rotation = 1;
+                        _fixedIsland.Position = new(_session.Size.X - SizeInTiles, _session.Size.Y - SizeInTiles);
+                    }
+                }
+            }
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -31,7 +31,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         };
 
 
-        private readonly Session _session;
+        protected readonly Session _session;
 
         public IslandElement Island { get; init; }
 

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -115,10 +115,17 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public override void OnDragged(Vector2 newPosition)
         {
-            // mark the island if it is out of bounds
             var mapArea = new Rect2(_session.Size - SizeInTiles + Vector2.Tile);
-            IsOutOfBounds = !newPosition.Within(mapArea);
 
+            // provide resistance against moving out of bounds
+            if (Element.Position.Within(mapArea) && !newPosition.Within(mapArea))
+            {
+                Vector2 safePosition = newPosition.Clamp(mapArea);
+                if ((safePosition - newPosition).Length < 150)
+                    newPosition = safePosition;
+            }
+
+            IsOutOfBounds = !newPosition.Within(mapArea);
             base.OnDragged(newPosition);
         }
     }

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -321,7 +321,16 @@ namespace AnnoMapEditor.UI.Controls
                 if (sender is IslandViewModel viewModel)
                 {
                     if (viewModel.IsOutOfBounds && !viewModel.IsDragging)
+                    {
                         session.Elements.Remove(viewModel.Element);
+
+                        // deselect the island if it was selected
+                        if (viewModel == _selectedElement)
+                        {
+                            _selectedElement = null;
+                            SelectedIsland = null;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added small improvements to the UI:

1. Automatically rotate and snap continental islands to the corners of the map.
Continental islands have special meshes extending beyond their back edges. If a continental island is places elsewhere on the map or rotated wrongly, these meshes will occlude other parts of the maps.

2. Reintroduced resistance when moving islands of the map
This was removed during my larger UI overhaul and now it is back.

3. Deselect islands when removing them
Previously the island properties would not clear when the selected island was removed.