### PR TITLE
Move PlayableArea scaling to separate control

### DIFF
--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml
@@ -1,0 +1,116 @@
+﻿<controls:DraggingControl x:Class="AnnoMapEditor.UI.Controls.MapTemplates.PlayableAreaControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls.MapTemplates"
+             xmlns:controls="clr-namespace:AnnoMapEditor.UI.Controls"
+             xmlns:converters="clr-namespace:AnnoMapEditor.UI.Converters"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance Type=local:PlayableAreaViewModel}"
+             d:DesignHeight="400" d:DesignWidth="400">
+
+    <controls:DraggingControl.Resources>
+        <converters:BoolToVisibility x:Key="VisibleOnTrue" />
+        <converters:BoolToVisibility x:Key="VisibleOnFalse" OnTrue="Collapsed" OnFalse="Visible" />
+        <converters:IntToGridLengthConverter x:Key="IntToGridLength" />
+    </controls:DraggingControl.Resources>
+    
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="{Binding PlayableSize, Mode=TwoWay, Converter={StaticResource IntToGridLength}}" 
+                              MinWidth="{Binding MinSize}" MaxWidth="{Binding MaxSize, Mode=OneWay}"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="{Binding PlayableSize, Mode=TwoWay, Converter={StaticResource IntToGridLength}}" 
+                           MinHeight="{Binding MinSize}" MaxHeight="{Binding MaxSize, Mode=OneWay}"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="1" Grid.Column="0" IsHitTestVisible="False" Background="Transparent" VerticalAlignment="Stretch" SizeChanged="MarginRightTop_SizeChanged"/>
+        <Border Grid.Row="0" Grid.Column="1" IsHitTestVisible="False" Background="Transparent" VerticalAlignment="Stretch" SizeChanged="MarginLeftTop_SizeChanged"/>
+
+        <GridSplitter Grid.Column="0" VerticalAlignment="Stretch" HorizontalAlignment="Right" Width="16" 
+                      Background="#C0315881" ResizeDirection="Columns" ResizeBehavior="CurrentAndNext"
+                      Cursor="SizeNWSE" Margin="0,32,0,40" DragIncrement="8" DragStarted="Splitter_DragStarted" DragCompleted="Splitter_DragCompleted"
+                      Visibility="{Binding RelativeSource={RelativeSource Self}, Path=IsEnabled, Converter={StaticResource VisibleOnTrue}}"/>
+        <GridSplitter Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Height="16" 
+                      Background="#C0315881" ResizeDirection="Rows" ResizeBehavior="CurrentAndNext" 
+                      Cursor="SizeNESW" Margin="32,0,40,0" DragIncrement="8" DragStarted="Splitter_DragStarted" DragCompleted="Splitter_DragCompleted"
+                      Visibility="{Binding RelativeSource={RelativeSource Self}, Path=IsEnabled, Converter={StaticResource VisibleOnTrue}}"/>
+
+
+
+        <Grid Grid.Row="0" Grid.Column="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" MinHeight="140"/>
+                <RowDefinition Height="14*"/>
+                <RowDefinition Height="*" MinHeight="140"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" MinWidth="140"/>
+                <ColumnDefinition Width="14*"/>
+                <ColumnDefinition Width="*" MinWidth="140"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="1" FontSize="{Binding MarginFontSize, Mode=OneWay}" Foreground="{StaticResource TextBrush}"
+                       VerticalAlignment="Center" HorizontalAlignment="Center" IsHitTestVisible="False"
+                       Visibility="{Binding ShowPlayableAreaMargins, Mode=OneWay, Converter={StaticResource VisibleOnTrue}}">
+                <TextBlock.LayoutTransform>
+                    <RotateTransform Angle="180"/>
+                </TextBlock.LayoutTransform>
+                    <Run Text="Margin:"/>
+                    <Run Text="{Binding PosY, Mode=OneWay}"/>
+            </TextBlock>
+
+
+            <TextBlock Grid.Row="2" Grid.Column="1" FontSize="{Binding MarginFontSize, Mode=OneWay}" Foreground="{StaticResource TextBrush}"
+                       VerticalAlignment="Center" HorizontalAlignment="Center" IsHitTestVisible="False"
+                       Visibility="{Binding ShowPlayableAreaMargins, Mode=OneWay, Converter={StaticResource VisibleOnTrue}}">
+                <TextBlock.LayoutTransform>
+                    <RotateTransform Angle="180"/>
+                </TextBlock.LayoutTransform>
+                    <Run Text="Margin:"/>
+                    <Run Text="{Binding MarginRightTop, Mode=OneWay}"/>
+            </TextBlock>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" FontSize="{Binding MarginFontSize, Mode=OneWay}" Foreground="{StaticResource TextBrush}"
+                       VerticalAlignment="Center" HorizontalAlignment="Center" IsHitTestVisible="False"
+                       Visibility="{Binding ShowPlayableAreaMargins, Mode=OneWay, Converter={StaticResource VisibleOnTrue}}">
+                <TextBlock.LayoutTransform>
+                    <RotateTransform Angle="90"/>
+                </TextBlock.LayoutTransform>
+                    <Run Text="Margin:"/>
+                    <Run Text="{Binding PosX, Mode=OneWay}"/>
+            </TextBlock>
+
+            <TextBlock Grid.Row="1" Grid.Column="2" FontSize="{Binding MarginFontSize, Mode=OneWay}" Foreground="{StaticResource TextBrush}"
+                       VerticalAlignment="Center" HorizontalAlignment="Center" IsHitTestVisible="False"
+                       Visibility="{Binding ShowPlayableAreaMargins, Mode=OneWay, Converter={StaticResource VisibleOnTrue}}">
+                <TextBlock.LayoutTransform>
+                    <RotateTransform Angle="90"/>
+                </TextBlock.LayoutTransform>
+                    <Run Text="Margin:"/>
+                    <Run Text="{Binding MarginLeftTop, Mode=OneWay}"/>
+            </TextBlock>
+
+            <!-- Main Background -->
+            <Border Grid.RowSpan="3" Grid.ColumnSpan="3"  BorderThickness="0" Background="#80182B3F" Panel.ZIndex="-1" IsHitTestVisible="False">
+
+            </Border>
+
+            <!-- Drag Part -->
+            <Border Grid.Row="0" Grid.Column="0" IsEnabled="True" Background="#C0315881" IsHitTestVisible="True" Cursor="Hand"
+                    Visibility="{Binding RelativeSource={RelativeSource Self}, Path=IsEnabled, Converter={StaticResource VisibleOnTrue}}">
+                <Viewbox Stretch="Uniform">
+                    <Path Stroke="{StaticResource TextBrush}" StrokeThickness="7" Margin="20" Data="
+                          M 0,25 L 0,0 25,0 
+                          M 50,0 L 75,0 75,25 
+                          M 75,50 L 75,75 50,75
+                          M 25,75 L 0,75 0,50"/>
+                </Viewbox>
+            </Border>
+        </Grid>
+    </Grid>
+</controls:DraggingControl>

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml.cs
@@ -1,0 +1,84 @@
+﻿using AnnoMapEditor.MapTemplates.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AnnoMapEditor.UI.Controls.MapTemplates
+{
+    /// <summary>
+    /// Interaktionslogik für PlayableAreaControl.xaml
+    /// </summary>
+    public partial class PlayableAreaControl : DraggingControl
+    {
+        public PlayableAreaControl(Session session)
+        {
+            ViewModel = new PlayableAreaViewModel(session);
+            session.MapSizeConfigChanged += OnSessionResized;
+
+            DataContext = ViewModel;
+            IsEnabled = false;
+            InitializeComponent();
+
+            PositionAndScale();
+        }
+
+        public PlayableAreaViewModel ViewModel { get; }
+
+        private void Splitter_DragCompleted(object sender, System.Windows.Controls.Primitives.DragCompletedEventArgs e)
+        {
+            if (DataContext is PlayableAreaViewModel viewModel)
+            {
+                viewModel.ResizingInProgress = false;
+            }
+        }
+
+        private void Splitter_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
+        {
+            if (DataContext is PlayableAreaViewModel viewModel)
+            {
+                viewModel.ResizingInProgress = true;
+            }
+        }
+
+        private void MarginLeftTop_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            ViewModel.MarginLeftTop = (int)e.NewSize.Width;
+        }
+
+        private void MarginRightTop_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            ViewModel.MarginRightTop = (int)e.NewSize.Height;
+        }
+
+        private void OnSessionResized(object? sender, Session.SessionResizeEventArgs args)
+        {
+            PositionAndScale();
+        }
+
+
+        private void PositionAndScale()
+        {
+            this.Width = ViewModel.ControlWidth;
+            this.Height = ViewModel.ControlHeight;
+
+            Canvas.SetLeft(this, ViewModel.PosX);
+            Canvas.SetTop(this, ViewModel.PosY);
+        }
+
+        public void SetShowPlayableAreaMargins(bool value)
+        {
+            ViewModel.ShowPlayableAreaMargins = value;
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
@@ -1,0 +1,200 @@
+﻿using AnnoMapEditor.MapTemplates.Models;
+using AnnoMapEditor.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnnoMapEditor.UI.Controls.MapTemplates
+{
+    public class PlayableAreaViewModel : DraggingViewModel
+    {
+        public PlayableAreaViewModel(Session session)
+        {
+            Session = session;
+            //Flip X/Y
+            this.PosY = session.PlayableArea.Position.X;
+            this.PosX = session.PlayableArea.Position.Y;
+
+            //Flip here as well?
+            this.PlayableSize = session.PlayableArea.Width;
+
+            this.DragEnded += OnDragEnded;
+            session.MapSizeConfigCommitted += OnSessionSizeCommitted;
+        }
+
+        private Session Session { get; init; }
+
+        private const int MinMargin = 32; //Arbitrary Value
+        private static readonly Vector2 MinMarginVector = new Vector2(MinMargin, MinMargin);
+
+        /// <summary>
+        /// Whether to show numeric values for the margins around the playable area on the control.
+        /// </summary>
+        public bool ShowPlayableAreaMargins
+        {
+            get => _showPlayableAreaMargins;
+            set
+            {
+                SetProperty(ref _showPlayableAreaMargins, value);
+            }
+        }
+        private bool _showPlayableAreaMargins = false;
+
+
+        public int PosX
+        {
+            get => _posX;
+            set
+            {
+                SetProperty(ref _posX, value, new string[] { nameof(MaxSize) });
+            }
+        }
+        private int _posX;
+        public int PosY
+        {
+            get => _posY;
+            set
+            {
+                SetProperty(ref _posY, value, new string[] { nameof(MaxSize) });
+            }
+        }
+        private int _posY;
+
+        public int ControlWidth => Session.Size.X - PosX;
+        public int ControlHeight => Session.Size.Y - PosY;
+
+        /// <summary>
+        /// Used for automatic font scaling to avoid clipping.
+        /// </summary>
+        public double MarginFontSize 
+        { 
+            get
+            {
+                const int FONTSIZE_CUTOFF = 880;
+                if (PlayableSize >= FONTSIZE_CUTOFF)
+                    return 100.0;
+                else
+                    //100 - 40xNormalized value below cutoff, as Fontsize 60 is safe even with 4-Figure margin
+                    return 100.0 - 40.0*(1.0 - ((PlayableSize - MinSize)/(double)(FONTSIZE_CUTOFF - MinSize)));
+            } 
+        }
+
+
+        public int MarginLeftTop
+        {
+            get => _marginLeftTop;
+            set
+            {
+                SetProperty(ref _marginLeftTop, value);
+            }
+        }
+        private int _marginLeftTop;
+
+        public int MarginRightTop
+        {
+            get => _marginRightTop;
+            set
+            {
+                SetProperty(ref _marginRightTop, value);
+            }
+        }
+        private int _marginRightTop;
+
+
+        public int PlayableSize
+        {
+            get => _playableSize;
+            set
+            {
+                SetProperty(ref _playableSize, value, new string[] { nameof(MarginFontSize) });
+            }
+        }
+        private int _playableSize;
+
+        /// <summary>
+        /// Maximum Size allowed during resizing.<br/>
+        /// Based on Position and minimum Margin.
+        /// </summary>
+        public int MaxSize => Math.Min(Session.Size.X - PosX - MinMargin, Session.Size.Y - PosY - MinMargin);
+
+        /// <summary>
+        /// Always 640 -> Fits 4 medium starters exactly.
+        /// </summary>
+        public int MinSize => 640; //Arbitrary Value
+
+
+        public bool ResizingInProgress
+        {
+            get => _resizingInProgress;
+            set
+            {
+                SetProperty(ref _resizingInProgress, value);
+                ResizeSessionValues();
+            }
+        }
+        private bool _resizingInProgress = false;
+
+
+        public override void OnDragged(Vector2 newPosition)
+        {
+            //This limits movement so that the minimum Margin is always remaining.
+            Vector2 newPos = newPosition.Clamp(MinMarginVector, new Vector2(Session.Size.X - PlayableSize - MinMargin, Session.Size.Y - PlayableSize - MinMargin));
+            PosX = newPos.X;
+            PosY = newPos.Y;
+
+            ResizeSessionValues();
+        }
+
+        private void OnDragEnded(object? sender, DragEndedEventArgs args)
+        {
+            ResizeSessionValues();
+        }
+
+        private bool LocalResizing { get; set; }
+        private void ResizeSessionValues()
+        {
+            LocalResizing = true;
+            if (ResizingInProgress || IsDragging)
+                Session.ResizeSession(Session.Size.X, (PosX, PosY, PosX + PlayableSize, PosY + PlayableSize));
+            else
+                Session.ResizeAndCommitSession(Session.Size.X, (PosX, PosY, PosX + PlayableSize, PosY + PlayableSize));
+
+            LocalResizing = false;
+        }
+
+        private void OnSessionSizeCommitted(object? sender, EventArgs _)
+        {
+            //Use this code only when the map size is resized (externally), to adapt the PlayableArea to the MapSize.
+            //Everything else about the PlayableArea gets handled internally already.
+            if(!LocalResizing)
+            {
+                OnPropertyChanged(nameof(MaxSize));
+
+                //The Following Min + if could be solved in one line by nesting two Mins, but that would be terrible to read.
+                int maxAllowedSizeX = Session.Size.X - PosX - MinMargin;
+                int maxAllowedSizeY = Session.Size.Y - PosY - MinMargin;
+                int maxAllowedSize = Math.Min(maxAllowedSizeX, maxAllowedSizeY);
+                if(PlayableSize > maxAllowedSize)
+                {
+                    if (maxAllowedSize >= MinSize)
+                    {
+                        PlayableSize = maxAllowedSize;
+                    }
+                    else
+                    {
+                        int offsetX = Math.Min(0, Session.Size.X - (MinSize + PosX + MinMargin));
+                        int offsetY = Math.Min(0, Session.Size.Y - (MinSize + PosY + MinMargin));
+
+                        PlayableSize = MinSize;
+                        //+= because offset will already be negative!
+                        PosX += offsetX;
+                        PosY += offsetY;
+                    }
+                }
+                ResizeSessionValues();
+            }
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -78,7 +78,7 @@ namespace AnnoMapEditor.UI.Controls
                 bool val = (bool)args.NewValue;
                 mvObject.playableRect.IsEnabled = val;
                 if (val)
-                    Panel.SetZIndex(mvObject.playableRect, 1);
+                    Panel.SetZIndex(mvObject.playableRect, 10);
                 else
                     Panel.SetZIndex(mvObject.playableRect, 0);
                 mvObject.EnableDisableIslands(!val);

--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml
@@ -53,15 +53,7 @@
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
-
-                    <!-- Playable Area -->
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="auto" />
-                    <!-- Avg Margin -->
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="auto" />
-                    <!-- Offsets -->
-                    <RowDefinition Height="auto" />
+                    
                 </Grid.RowDefinitions>
 
                 <!-- Map Size -->
@@ -88,125 +80,11 @@
                     <TextBlock Grid.Column="2" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MaxMapSize, Mode=OneTime}"/>
                 </Grid>
 
-
-                <Separator Grid.Row="2" Grid.ColumnSpan="2"/>
-
-                <!-- Margin/Playable Area -->
-                <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" Margin="2,2,0,0" HorizontalAlignment="Left">
-                    
-                    <!-- Margin Mode Toggle -->
-                    <local:FancyToggle Label="Margin Mode:" OffText="Centered" OnText="Custom" 
-                                       IsChecked="{Binding MarginMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                       ValueChanged="FancyToggle_ValueChanged"/>
-
-                    
-                </StackPanel>
-
-                <TextBlock Grid.Row="4" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" Text="Playable Area:" />
-                <TextBlock Grid.Row="4" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,2,2,0" >
-                                <Run Text="{Binding PlayableSize, Mode=OneWay}"/>
-                                <Run Text="x"/>
-                                <Run Text="{Binding PlayableSize, Mode=OneWay}"/>
-                </TextBlock>
-
-                <!-- Avg Margin -->
-                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Average Margin:" 
-                           Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}"/>
-                <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Margin:" 
-                           Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityInverted}}"/>
-                <TextBlock Grid.Row="5" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
-                                <Run Text="{Binding AverageMargin, Mode=OneWay}"/>
-                </TextBlock>
-
-                <Grid Grid.Row="6" Grid.ColumnSpan="2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MinMargin, Mode=OneWay}"/>
-                    <Slider Grid.Column="1" VerticalAlignment="Center" 
-                                        Minimum="{Binding MinMargin, Mode=OneWay}" 
-                                        Maximum="{Binding MaxMargin, Mode=OneWay}" 
-                                        Value="{Binding AverageMargin, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                        TickFrequency="{Binding MarginStepSize, Mode=OneWay}" IsSnapToTickEnabled="True"
-                                        Thumb.DragCompleted="Slider_DragCompleted"
-                                        Thumb.DragStarted="Slider_DragStarted"/>
-                    <TextBlock Grid.Column="2" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MaxMargin, Mode=OneWay}"/>
-                </Grid>
+                <local:FancyToggle Grid.Row="2" Label="Modify Playable Area" OffText="Off" OnText="On" 
+                                       IsChecked="{Binding EditPlayableArea, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                 
-                <!-- Offsets -->
-                <Grid Grid.Row="7" Grid.ColumnSpan="2" Visibility="{Binding MarginMode, Mode=OneWay, Converter={StaticResource BoolToVisibility}}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <!-- Offset X -->
-                        <RowDefinition Height="auto" />
-                        <RowDefinition Height="auto" />
-                        <!-- Offset Y -->
-                        <RowDefinition Height="auto" />
-                        <RowDefinition Height="auto" />
-                    </Grid.RowDefinitions>
-
-                    <!-- Offset X -->
-                    <TextBlock Grid.Row="0" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Offset X:" />
-                    <TextBlock Grid.Row="0" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
-                                <Run Text="{Binding OffsetX, Mode=OneWay}"/>
-                    </TextBlock>
-
-                    <Grid Grid.Row="1" Grid.ColumnSpan="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MinOffset, Mode=OneWay}"/>
-                        <Slider Grid.Column="1" VerticalAlignment="Center" 
-                                        Minimum="{Binding MinOffset, Mode=OneWay}" 
-                                        Maximum="{Binding MaxOffset, Mode=OneWay}" 
-                                        Value="{Binding OffsetX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                        TickFrequency="8" IsSnapToTickEnabled="True"
-                                        Thumb.DragCompleted="Slider_DragCompleted"
-                                        Thumb.DragStarted="Slider_DragStarted"/>
-                        <TextBlock Grid.Column="2" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MaxOffset, Mode=OneWay}"/>
-                    </Grid>
-
-                    <!-- Offset Y -->
-                    <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2" Text="Offset Y:" />
-                    <TextBlock Grid.Row="2" Grid.Column="1" Style="{StaticResource DefaultLabelStyle}" Margin="2,0,2,2">
-                                <Run Text="{Binding OffsetY, Mode=OneWay}"/>
-                    </TextBlock>
-
-                    <Grid Grid.Row="3" Grid.ColumnSpan="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MinOffset, Mode=OneWay}"/>
-                        <Slider Grid.Column="1" VerticalAlignment="Center" 
-                                        Minimum="{Binding MinOffset, Mode=OneWay}" 
-                                        Maximum="{Binding MaxOffset, Mode=OneWay}" 
-                                        Value="{Binding OffsetY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                        TickFrequency="8" IsSnapToTickEnabled="True"
-                                        Thumb.DragCompleted="Slider_DragCompleted"
-                                        Thumb.DragStarted="Slider_DragStarted"/>
-                        <TextBlock Grid.Column="2" Style="{StaticResource DefaultLabelStyle}" Text="{Binding MaxOffset, Mode=OneWay}"/>
-                    </Grid>
-                </Grid>
-                <!-- Margin OK Info-->
-                <emoji:TextBlock Text="&#x26a0; PlayableArea not centered! Going back to centered mode will reset offsets."
-                                 MaxWidth="180"
-                                 Grid.ColumnSpan="2"
-                                 TextWrapping="Wrap"
-                                 HorizontalAlignment="Left"
-                                 Style="{StaticResource DefaultLabelStyle}"
-                                 Margin="2,0,2,2"
-                                 Grid.Row="8"
-                                 Visibility="{Binding NonCenteredMarginWarning, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisibility}}">
-                </emoji:TextBlock>
+                <local:FancyToggle Grid.Row="3" Label="Show Playable Area Margins" OffText="Off" OnText="On" 
+                                       IsChecked="{Binding ShowPlayableAreaMargins, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
 
             </Grid>

--- a/AnnoMapEditor/UI/Controls/SessionProperties.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/SessionProperties.xaml.cs
@@ -17,6 +17,7 @@ namespace AnnoMapEditor.UI.Controls
             
         }
 
+        
         private void Slider_DragCompleted(object sender, System.Windows.Controls.Primitives.DragCompletedEventArgs e)
         {
             if (DataContext is SessionPropertiesViewModel viewModel)
@@ -30,14 +31,6 @@ namespace AnnoMapEditor.UI.Controls
             if (DataContext is SessionPropertiesViewModel viewModel)
             {
                 viewModel.DragInProgress = true;
-            }
-        }
-
-        private void FancyToggle_ValueChanged(object sender, RoutedEventArgs e)
-        {
-            if (DataContext is SessionPropertiesViewModel viewModel && viewModel.IsMarginNonCentered)
-            {
-                viewModel.Center();
             }
         }
     }

--- a/AnnoMapEditor/UI/Controls/SessionPropertiesViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/SessionPropertiesViewModel.cs
@@ -46,18 +46,19 @@ namespace AnnoMapEditor.UI.Controls
             if (allowSessionUpdate)
             {
                 if (DragInProgress)
-                    _session.ResizeSession(MapSize, (AverageMargin + OffsetX, AverageMargin + OffsetY, MapSize - AverageMargin + OffsetX, MapSize - AverageMargin + OffsetY));
+                    _session.ResizeSession(MapSize, PlayableAreaAsTuple());
                 else
                 {
-                    //Apply Margin and Offset Values even if they were implicitly clamped
-                    //This is needed because the clamped values would be used on export too.
-                    _averageMargin = AverageMargin;
-                    _offsetX = OffsetX;
-                    _offsetY = OffsetY;
-
-                    _session.ResizeAndCommitSession(MapSize, (AverageMargin + OffsetX, AverageMargin + OffsetY, MapSize - AverageMargin + OffsetX, MapSize - AverageMargin + OffsetY));
+                    _session.ResizeAndCommitSession(MapSize, PlayableAreaAsTuple());
                 }
             }
+        }
+
+        private (int x1, int y1, int x2, int y2) PlayableAreaAsTuple()
+        {
+            return (_session.PlayableArea.X, _session.PlayableArea.Y, 
+                _session.PlayableArea.X + _session.PlayableArea.Width, 
+                _session.PlayableArea.Y + _session.PlayableArea.Height);
         }
 
         public Region[] Regions { get; } = Region.All;
@@ -67,144 +68,36 @@ namespace AnnoMapEditor.UI.Controls
             get => _mapSize;
             set
             {
-                SetProperty(ref _mapSize, 
-                    value, 
-                    new string[] {
-                        nameof(AverageMargin),
-                        nameof(OffsetY),
-                        nameof(OffsetX),
-                        nameof(MinOffset),
-                        nameof(MaxOffset),
-                        nameof(MaxMargin), 
-                        nameof(PlayableSize)
-                    });
+                SetProperty(ref _mapSize, value);
                 ResizeSessionValues();
             }
         }
         private int _mapSize = 2560;
 
 
-        public bool MarginMode
+        public bool EditPlayableArea
         {
-            get => _marginMode;
+            get => _editPlayableArea;
             set
             {
-                SetProperty(ref _marginMode,
-                    value,
-                    new string[] {
-                        nameof(MarginStepSize),
-                        nameof(NonCenteredMarginWarning)
-                    });
+                SetProperty(ref _editPlayableArea, value);
             }
         }
-        private bool _marginMode = false;
+        private bool _editPlayableArea = false;
 
-        public int MarginStepSize
+        public bool ShowPlayableAreaMargins
         {
-            get => MarginMode ? 4 : 8;
-        }
-
-        public int AverageMargin
-        {
-            get => Math.Clamp(_averageMargin, MIN_SINGLE_MARGIN, MapSize / 4);
+            get => _showPlayableAreaMargins;
             set
             {
-                SetProperty(ref _averageMargin, 
-                    value, 
-                    new string[] {
-                        nameof(NonCenteredMarginWarning),
-                        nameof(OffsetX),
-                        nameof(OffsetY),
-                        nameof(MinOffset),
-                        nameof(MaxOffset),
-                        nameof(PlayableSize)
-                    });
-
-                //Handle Avg. Margin with a half tile
-                //(which means an uneven number of tiles for both margin and playable area)
-                AlignOffsetsToMargin();
-
-                ResizeSessionValues();
+                SetProperty(ref _showPlayableAreaMargins, value);
             }
         }
-        private int _averageMargin = MIN_SINGLE_MARGIN;
+        private bool _showPlayableAreaMargins = false;
 
-        private void AlignOffsetsToMargin()
-        {
-            //Non-Tile matching Margin needs an offset of 4.
-            if (AverageMargin % 8 == 4)
-            {
-                if (OffsetX % 8 == 0)
-                {
-                    OffsetX += 4;
-                }
-                if (OffsetY % 8 == 0)
-                {
-                    OffsetY += 4;
-                }
-            }
-            else if (AverageMargin % 8 == 0)
-            {
-                if (Math.Abs(OffsetX % 8) == 4)
-                {
-                    OffsetX -= 4;
-                }
-                if (Math.Abs(OffsetY % 8) == 4)
-                {
-                    OffsetY -= 4;
-                }
-            }
-        }
-
-        public bool NonCenteredMarginWarning
-        {
-            //For a warning when not all Margins are equal, but we are in MarginMode Centered
-            get => IsMarginNonCentered;
-        }
-
-        public bool IsMarginNonCentered
-        {
-            get => OffsetY != 0 || OffsetX != 0;
-        }
-
-        public int OffsetY
-        {
-            get => Math.Clamp(_offsetY, MinOffset, MaxOffset);
-            set
-            {
-                SetProperty(ref _offsetY, value, new string[] { nameof(NonCenteredMarginWarning) });
-                ResizeSessionValues();
-            }
-        }
-        private int _offsetY = 0;
-
-        public int OffsetX
-        {
-            get => Math.Clamp(_offsetX, MinOffset, MaxOffset);
-            set
-            {
-                SetProperty(ref _offsetX, value, new string[] { nameof(NonCenteredMarginWarning)});
-                ResizeSessionValues();
-            }
-        }
-        private int _offsetX = 0;
-
-
-        public int PlayableSize
-        {
-            get => MapSize - (AverageMargin * 2);
-        }
 
         public int MaxMapSize { get => 4096; } //Arbitrary Maximum, but larger would be absolutely useless
         public int MinMapSize { get => 704; } //Smallest playable Size with 4 reliable medium starter islands
-
-        public int MaxMargin { get => MapSize/4; }
-        public int MinMargin { get => MIN_SINGLE_MARGIN; }
-
-        public int MinOffset { get => -_averageMargin; }
-        public int MaxOffset { get => _averageMargin; }
-
-        private const int MIN_SINGLE_MARGIN = 32; //Arbitrary Value
 
         public bool DragInProgress
         {
@@ -225,15 +118,6 @@ namespace AnnoMapEditor.UI.Controls
             _selectedRegion = _session.Region;
 
             MapSize = session.Size.X;
-            AverageMargin = (session.Size.X - session.PlayableArea.Width) / 2;
-
-            OffsetX = session.PlayableArea.X - AverageMargin;
-            OffsetY = session.PlayableArea.Y - AverageMargin;
-
-            if (IsMarginNonCentered)
-            {
-                MarginMode = true;
-            }
 
             allowSessionUpdate = true;
 
@@ -251,12 +135,6 @@ namespace AnnoMapEditor.UI.Controls
         private void HandleSessionSizeCommitted(object? sender, EventArgs _)
         {
             UpdateMapSizeText();
-        }
-
-        public void Center()
-        { 
-            OffsetX= 0;
-            OffsetY=0;
         }
     }
 }

--- a/AnnoMapEditor/UI/Converters/IntToGridLengthConverter.cs
+++ b/AnnoMapEditor/UI/Converters/IntToGridLengthConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace AnnoMapEditor.UI.Converters
+{
+    [ValueConversion(typeof(int), typeof(GridLength))]
+    public class IntToGridLengthConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is int intValue)
+                return new GridLength(intValue);
+            throw new ArgumentException("Input was not an int.");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is GridLength gridLength)
+                if (gridLength.IsAbsolute)
+                    return (int)(gridLength.Value + 0.5);
+                else
+                    throw new ArgumentException("Can only convert Absolute GridLengths.");
+            throw new ArgumentException("Input was not a GridLength.");
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Windows/Main/MainWindow.xaml
+++ b/AnnoMapEditor/UI/Windows/Main/MainWindow.xaml
@@ -42,6 +42,8 @@
                 Grid.Column="1"
                 Grid.Row="0"
                 SelectedIsland="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=DataContext.SelectedIsland, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                EditPlayableArea="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=DataContext.SessionProperties.EditPlayableArea, Mode=OneWay}"
+                ShowPlayableAreaMargins="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=DataContext.SessionProperties.ShowPlayableAreaMargins, Mode=OneWay}"
                 DataContext="{Binding Session, Mode=OneWay}" />
         
         <!-- session properties -->


### PR DESCRIPTION
The scaling of the PlayableArea with sliders is very unintuitive. Instead of that, now there is a "Edit Playable Area" Mode which gets enabled in the Session Properties. In that mode, the Playable Area can be dragged and resized (by draggable bars) on the MapView. There is also an option to display the margins on each side of the playable area for more precise positioning.