### PR TITLE
Fix mod export and template loading

### DIFF
--- a/AnnoMapEditor/DataArchives/Assets/Models/IslandAsset.cs
+++ b/AnnoMapEditor/DataArchives/Assets/Models/IslandAsset.cs
@@ -10,7 +10,7 @@ namespace AnnoMapEditor.DataArchives.Assets.Models
 
         public string FilePath { get; init; }
 
-        public BitmapImage Thumbnail { get; init; }
+        public BitmapImage? Thumbnail { get; init; }
 
         public Region Region { get; init; }
 

--- a/AnnoMapEditor/DataArchives/Assets/Repositories/IslandRepository.cs
+++ b/AnnoMapEditor/DataArchives/Assets/Repositories/IslandRepository.cs
@@ -127,6 +127,22 @@ namespace AnnoMapEditor.DataArchives.Assets.Repositories
                 return IslandType.Normal;
         }
 
+        public static IslandSize DetectDefaultIslandSizeFromPath(string filePath)
+        {
+            if (filePath.Contains("_d_"))
+                return IslandSize.Default;
+            else if (filePath.Contains("_s_"))
+                return IslandSize.Small;
+            else if (filePath.Contains("_m_"))
+                return IslandSize.Medium;
+            else if (filePath.Contains("_l_"))
+                return IslandSize.Large;
+            else if (filePath.Contains("_c_"))
+                return IslandSize.Continental;
+            else
+                return IslandSize.Default;
+        }
+
 
         public IEnumerator<IslandAsset> GetEnumerator() => _byFilePath.Values.GetEnumerator();
 

--- a/AnnoMapEditor/Mods/Models/Mod.cs
+++ b/AnnoMapEditor/Mods/Models/Mod.cs
@@ -101,7 +101,7 @@ namespace AnnoMapEditor.Mods.Models
                     {
                         File.Copy(a7tInfoPath, a7tBasePath + $"_{size}_enlarged.a7tinfo");
                         File.Copy(a7tPath,     a7tBasePath + $"_{size}_enlarged.a7t");
-                        File.Copy(a7tInfoPath, a7tBasePath + $"_{size}_enlarged.a7te");
+                        File.Copy(a7tePath,    a7tBasePath + $"_{size}_enlarged.a7te");
                     }
                 }
             }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -44,6 +44,18 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
             if (e.PropertyName == nameof(FixedIslandElement.Rotation))
                 UpdateThumbnailRotation();
+
+            if (e.PropertyName == nameof(FixedIslandElement.IslandAsset))
+                Redraw();
+        }
+
+        private void Redraw()
+        {
+            OnPropertyChanged(nameof(Label));
+            OnPropertyChanged(nameof(SizeInTiles));
+            OnPropertyChanged(nameof(Thumbnail));
+            OnPropertyChanged(nameof(RandomizeRotation));
+            UpdateThumbnailRotation();
         }
 
         private void UpdateThumbnailRotation()

--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using AnnoMapEditor.MapTemplates.Enums;
 using AnnoMapEditor.MapTemplates.Models;
 using AnnoMapEditor.Utilities;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Media.Imaging;
 
@@ -30,8 +31,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             _fixedIsland = fixedIsland;
             _isContinentalIsland = _fixedIsland.IslandAsset.IslandSize.FirstOrDefault() == IslandSize.Continental;
 
-            UpdateThumbnailRotation();
             SnapContinentalIsland();
+            UpdateThumbnailRotation();
 
             fixedIsland.PropertyChanged += FixedIsland_PropertyChanged;
         }
@@ -72,20 +73,22 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             {
                 Vector2 islandCenter = _fixedIsland.Position;
                 Vector2 mapCenterOffset = new((_session.Size.X - SizeInTiles) / 2, (_session.Size.Y - SizeInTiles) / 2);
+                string islandFileName = System.IO.Path.GetFileNameWithoutExtension(_fixedIsland.IslandAsset.FilePath);
+                int rotationOffset = ContinentalRotationAtTop[islandFileName];
 
                 if (islandCenter.X <= mapCenterOffset.X)
                 {
                     // bottom
                     if (islandCenter.Y <= mapCenterOffset.Y)
                     {
-                        _fixedIsland.Rotation = 3;
+                        _fixedIsland.Rotation = (byte)((2 + rotationOffset) % 4);
                         _fixedIsland.Position = new(0, 0);
                     }
 
                     // right
                     else
                     {
-                        _fixedIsland.Rotation = 0;
+                        _fixedIsland.Rotation = (byte)((3 + rotationOffset) % 4);
                         _fixedIsland.Position = new(0, _session.Size.Y - SizeInTiles);
                     }
                 }
@@ -94,18 +97,24 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                     // left
                     if (islandCenter.Y <= mapCenterOffset.Y)
                     {
-                        _fixedIsland.Rotation = 2;
+                        _fixedIsland.Rotation = (byte)((1 + rotationOffset)%4);
                         _fixedIsland.Position = new(_session.Size.X - SizeInTiles, 0);
                     }
 
                     // top
                     else
                     {
-                        _fixedIsland.Rotation = 1;
+                        _fixedIsland.Rotation = (byte)((0 + rotationOffset)%4);
                         _fixedIsland.Position = new(_session.Size.X - SizeInTiles, _session.Size.Y - SizeInTiles);
                     }
                 }
             }
         }
+
+        private static readonly Dictionary<string, int> ContinentalRotationAtTop = new Dictionary<string, int>()
+        {
+            { "colony01_c_01", 0 },
+            { "moderate_c_01", 1}
+        };
     }
 }

--- a/AnnoMapEditor/Utilities/Settings.cs
+++ b/AnnoMapEditor/Utilities/Settings.cs
@@ -17,6 +17,11 @@ namespace AnnoMapEditor.Utilities
 
         public static Settings Instance { get; } = new();
 
+        /// <summary>
+        /// Is Invoked when loading all repositories from the game path finishes.
+        /// </summary>
+        public event EventHandler? LoadingFinished;
+
         public IDataArchive DataArchive
         {
             get => _dataArchive;
@@ -220,6 +225,12 @@ namespace AnnoMapEditor.Utilities
                 {
                     LoadingDoneTrigger.Set();
                 }
+
+                //If not Dispatched to UI thread, only the first item will be invoked somehow?
+                Dispatch(() =>
+                {
+                    LoadingFinished?.Invoke(this, EventArgs.Empty);
+                });
             }
         }
 
@@ -227,7 +238,6 @@ namespace AnnoMapEditor.Utilities
         {
             if (Application.Current?.Dispatcher != null)
                 Application.Current.Dispatcher.Invoke(action);
-
             else
                 action();
         }


### PR DESCRIPTION
Some fixes for the mod export (enlarged map mods exported the wrong a7te file), and template loading (the Manola continental island defaulted to the wrong rotations when snapping to corners) (when loading a map template before game file loading was finished, the app crashed).