### PR TITLE
Fix Island removal on Map resize

### DIFF
--- a/AnnoMapEditor/MapTemplates/Models/Session.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Session.cs
@@ -36,6 +36,13 @@ namespace AnnoMapEditor.MapTemplates.Models
         }
         private Region _region;
 
+        public bool ResizingInProgress
+        {
+            get => _resizingInProgress;
+            set => SetProperty(ref _resizingInProgress, value);
+        }
+        private bool _resizingInProgress = false;
+
         private MapTemplateDocument _template = new();
 
         public event EventHandler<SessionResizeEventArgs>? MapSizeConfigChanged;
@@ -178,6 +185,8 @@ namespace AnnoMapEditor.MapTemplates.Models
 
         public void ResizeSession(int mapSize, (int x1, int y1, int x2, int y2) playableAreaMargins)
         {
+            ResizingInProgress = true;
+
             Vector2 oldMapSize = new(Size);
             Size = new(mapSize, mapSize);
 
@@ -203,6 +212,8 @@ namespace AnnoMapEditor.MapTemplates.Models
 
             Vector2 oldPlayableSize = new(PlayableArea.Width, PlayableArea.Height);
             PlayableArea = new(_template.MapTemplate.PlayableArea);
+
+            ResizingInProgress = false;
 
             MapSizeConfigChanged?.Invoke(this, new SessionResizeEventArgs(oldMapSize, oldPlayableSize));
             MapSizeConfigCommitted?.Invoke(this, new EventArgs());

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -125,8 +125,15 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                     newPosition = safePosition;
             }
 
-            IsOutOfBounds = !newPosition.Within(mapArea);
+            BoundsCheck(newPosition);
             base.OnDragged(newPosition);
+        }
+
+        public void BoundsCheck(Vector2? pos = null)
+        {
+            var mapArea = new Rect2(_session.Size - SizeInTiles + Vector2.Tile);
+            Vector2 position = pos ?? Element.Position;
+            IsOutOfBounds = !position.Within(mapArea);
         }
     }
 }


### PR DESCRIPTION
Islands get now properly marked for removal on map resize and removed when the resize is committed. Starting spots get now moved in bounds correctly on resizing both the Map as well as the Playable Area.

Closes #59 .