### PR TITLE
Added a locking mechanism to islands

### DIFF
--- a/AnnoMapEditor/MapTemplates/Models/MapElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/MapElement.cs
@@ -14,6 +14,19 @@ namespace AnnoMapEditor.MapTemplates.Models
         }
         private Vector2 _position = Vector2.Zero;
 
+        public bool IsLocked 
+        {
+            get => _isLocked;
+            set => SetProperty(ref _isLocked, value, new[] { nameof(IsUnlocked) });
+        }
+        private bool _isLocked;
+
+        public bool IsUnlocked
+        {
+            get => !_isLocked;
+            set => SetProperty(ref _isLocked, !value, new[] { nameof(IsLocked) });
+        }
+
 
         public MapElement()
         {

--- a/AnnoMapEditor/UI/Controls/IslandProperties/FixedIslandProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/IslandProperties/FixedIslandProperties.xaml
@@ -34,49 +34,58 @@
                    HorizontalAlignment="Left"
                    Text="Fixed Island"
                    Margin="0"/>
-        
-        <!-- Label -->
-        <TextBlock Text="Label"
-                   Style="{StaticResource SubHeaderLabelStyle}"/>
-        <TextBox Margin="2"
-                     Text="{Binding FixedIsland.Label, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <!-- Rotation -->
-        <TextBlock Text="Rotation"
+        <!-- lockable properties -->
+        <StackPanel IsEnabled="{Binding FixedIsland.IsUnlocked}">
+
+            <!-- Label -->
+            <TextBlock Text="Label"
                    Style="{StaticResource SubHeaderLabelStyle}"/>
-        <local:FancyToggle Label="Randomize"
+            <TextBox Margin="2"
+                     Text="{Binding FixedIsland.Label, UpdateSourceTrigger=PropertyChanged}" />
+
+            <!-- Rotation -->
+            <TextBlock Text="Rotation"
+                   Style="{StaticResource SubHeaderLabelStyle}"/>
+            <local:FancyToggle Label="Randomize"
                            OnText="Yes" OffText="No"
                            IsEnabled="{Binding IsContinentalIsland, Converter={StaticResource BooleanNot}}"
                            IsChecked="{Binding FixedIsland.RandomizeRotation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <Button Grid.Column="0"
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <Button Grid.Column="0"
                     Click="OnRotateCounterClockwise"
                     ToolTip="rotate counter clockwise"
                     Content="⤹"
                     Visibility="{Binding FixedIsland.RandomizeRotation, Converter={StaticResource VisibleOnFalse}}"/>
-            <Button Grid.Column="1"
+                <Button Grid.Column="1"
                     Click="OnRotateClockwise" 
                     ToolTip="rotate clockwise"
                     Content="⤸"
                     Visibility="{Binding FixedIsland.RandomizeRotation, Converter={StaticResource VisibleOnFalse}}"/>
-        </Grid>
+            </Grid>
 
-        <!-- IslandType -->
-        <TextBlock Text="Island Type"
-                   Style="{StaticResource SubHeaderLabelStyle}"/>
-        <ComboBox Margin="4"
-                      ItemsSource="{Binding IslandTypeItems}"
-                      SelectedItem="{Binding FixedIsland.IslandType}"/>
+            <!-- IslandType -->
+            <TextBlock Text="Island Type"
+                        Style="{StaticResource SubHeaderLabelStyle}"/>
+            <ComboBox Margin="4"
+                  ItemsSource="{Binding IslandTypeItems}" />
 
-        <!-- Fertilities -->
-        <fertilities:FertilityControl DataContext="{Binding FertilitiesViewModel}" />
+            <!-- Fertilities -->
+            <fertilities:FertilityControl DataContext="{Binding FertilitiesViewModel}" />
+
+            <!-- Slots -->
+            <slots:SlotsControl DataContext="{Binding SlotsViewModel}" />
+
+        </StackPanel>
         
-        <!-- Slots -->
-        <slots:SlotsControl DataContext="{Binding SlotsViewModel}" />
-
+        <!-- Locking -->
+        <local:FancyToggle Label="Lock Island"
+                           OnText="Locked" OffText="Unlocked"
+                           Margin="0,32"
+                           IsChecked="{Binding FixedIsland.IsLocked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
     </StackPanel>
 </UserControl>

--- a/AnnoMapEditor/UI/Controls/IslandProperties/RandomIslandProperties.xaml
+++ b/AnnoMapEditor/UI/Controls/IslandProperties/RandomIslandProperties.xaml
@@ -17,6 +17,7 @@
                 <ResourceDictionary Source="../../Resources/Styles.xaml" />
                 <ResourceDictionary>
                     <converters:ObjectToVisibility x:Key="CollapsedOnNull" />
+                    <converters:BooleaNotConverter x:Key="BooleanNot" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -31,25 +32,35 @@
                    Text="Random Island"
                    Margin="0"/>
 
-        <!-- Label -->
-        <TextBlock Text="Label"
-                   Style="{StaticResource SubHeaderLabelStyle}"/>
-        <TextBox Margin="2"
-                    Text="{Binding RandomIsland.Label, UpdateSourceTrigger=PropertyChanged}"/>
+        <!-- lockable properties -->
+        <StackPanel IsEnabled="{Binding RandomIsland.IsUnlocked}">
 
-        <!-- IslandType -->
-        <TextBlock Text="Island Type"
-                   Style="{StaticResource SubHeaderLabelStyle}"/>
-        <ComboBox Margin="2"
-                    ItemsSource="{Binding IslandTypeItems}"
-                    SelectedItem="{Binding RandomIsland.IslandType}"/>
+            <!-- Label -->
+            <TextBlock Text="Label"
+                       Style="{StaticResource SubHeaderLabelStyle}"/>
+            <TextBox Margin="2"
+                     Text="{Binding RandomIsland.Label, UpdateSourceTrigger=PropertyChanged}" />
 
-        <!-- IslandSize -->
-        <TextBlock Text="Island Size"
-                   Style="{StaticResource SubHeaderLabelStyle}"/>
-        <ComboBox Margin="2"
-                    ItemsSource="{Binding IslandSizeItems}"
-                    SelectedItem="{Binding RandomIsland.IslandSize}"/>
-            
+            <!-- IslandType -->
+            <TextBlock Text="Island Type"
+                       Style="{StaticResource SubHeaderLabelStyle}"/>
+            <ComboBox Margin="2"
+                      ItemsSource="{Binding IslandTypeItems}"
+                      SelectedItem="{Binding RandomIsland.IslandType}" />
+
+            <!-- IslandSize -->
+            <TextBlock Text="Island Size"
+                      Style="{StaticResource SubHeaderLabelStyle}"/>
+            <ComboBox Margin="2"
+                      ItemsSource="{Binding IslandSizeItems}"
+                      SelectedItem="{Binding RandomIsland.IslandSize}" />
+
+        </StackPanel>
+
+        <!-- Locking -->
+        <local:FancyToggle Label="Lock Island"
+                           OnText="Locked" OffText="Unlocked"
+                           Margin="0,32"
+                           IsChecked="{Binding RandomIsland.IsLocked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
     </StackPanel>
 </UserControl>

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml
@@ -45,6 +45,30 @@
                      Fill="Gold"
                      Points="0,0 40,0 0,40"
                      Visibility="{Binding RandomizeRotation, Converter={StaticResource VisibleOnFalse}, FallbackValue=Hidden}"/>
+
+        </Canvas>
+
+        <!-- lock icon-->
+        <Canvas RenderTransformOrigin="0.5,0.5"
+                Width="{Binding SizeInTiles}"
+                Height="{Binding SizeInTiles}"
+                Visibility="{Binding Island.IsLocked, Converter={StaticResource VisibleOnTrue}}">
+            <Canvas.RenderTransform>
+                <RotateTransform Angle="180"/>
+            </Canvas.RenderTransform>
+
+            <Image Source="{Binding LockIconOutline}"
+                   RenderTransformOrigin="0.5,0.5">
+                <Image.RenderTransform>
+                    <RotateTransform Angle="-45"/>
+                </Image.RenderTransform>
+            </Image>
+            <Image Source="{Binding LockIcon}"
+                   RenderTransformOrigin="0.5,0.5">
+                <Image.RenderTransform>
+                    <RotateTransform Angle="-45"/>
+                </Image.RenderTransform>
+            </Image>
         </Canvas>
 
         <!-- Label -->

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace AnnoMapEditor.UI.Controls.MapTemplates
+﻿using System.Windows.Media;
+
+namespace AnnoMapEditor.UI.Controls.MapTemplates
 {
     /// <summary>
     /// Interaction logic for IslandControl.xaml

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -9,6 +9,11 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 {
     public abstract class IslandViewModel : MapElementViewModel
     {
+        public static ImageSource LockIcon { get; } = Settings.Instance.DataArchive.TryLoadIcon("data/ui/2kimages/main/icons/icon_lock_0.dds")!;
+
+        public static ImageSource LockIconOutline { get; } = Settings.Instance.DataArchive.TryLoadIcon("data/ui/2kimages/main/icons/icon_lock_outline_0.dds")!;
+
+
         static readonly Dictionary<string, SolidColorBrush> BorderBrushes = new()
         {
             ["Normal"] = new(Color.FromArgb(255, 8, 172, 137)),

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
@@ -23,7 +23,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public override void OnDragged(Vector2 newPosition)
         {
-            Element.Position = newPosition;
+            if (!Element.IsLocked)
+                Element.Position = newPosition;
         }
     }
 }


### PR DESCRIPTION
This PR adds a toggle to lock islands. Locked islands can neither be moved nor have any of their properties changed. This prevents moving islands by accident.

Secondly it serves as a foundation for supporting custom Arctic and Enbesa. Due to the presence of custom triggers and other GameObjects, changing certain islands would break quests in those regions. Locking them does not solve all issues but it is a first step in the right direction.

In the future warning messages should be added if the user attempts to unlock an island containing GameObjects.

![image](https://github.com/anno-mods/AnnoMapEditor/assets/19320074/a1141ede-40eb-40bb-9858-a9e1266f7f61)
