### PR TITLE
add dragging of multiple elements

### DIFF
--- a/AnnoMapEditor.Tests/RoundTrip.cs
+++ b/AnnoMapEditor.Tests/RoundTrip.cs
@@ -1,3 +1,4 @@
+using AnnoMapEditor.MapTemplates.Enums;
 using AnnoMapEditor.MapTemplates.Models;
 using AnnoMapEditor.MapTemplates.Serializing;
 using AnnoMapEditor.Tests.Utils;
@@ -18,7 +19,8 @@ namespace AnnoMapEditor.Tests
             await Settings.Instance.AwaitLoadingAsync();
 
             using Stream inputXml = File.OpenRead(filePath);
-            Session? session = await Session.FromXmlAsync(inputXml, filePath);
+            Region region = Region.DetectFromPath(filePath);
+            Session? session = await Session.FromXmlStreamAsync(region, inputXml);
 
             Assert.NotNull(session);
 
@@ -30,7 +32,7 @@ namespace AnnoMapEditor.Tests
                 await Serializer.WriteAsync(export!, a7tinfo);
 
                 a7tinfo.Position = 0;
-                session = await Session.FromA7tinfoAsync(a7tinfo, filePath);
+                session = await Session.FromBinaryStreamAsync(region, a7tinfo);
                 Assert.NotNull(session);
             }
 

--- a/AnnoMapEditor/MapTemplates/Models/FixedIslandElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/FixedIslandElement.cs
@@ -25,7 +25,11 @@ namespace AnnoMapEditor.MapTemplates.Models
         { 
             get => _islandAsset;
             [MemberNotNull(nameof(_islandAsset))]
-            private set => SetProperty(ref _islandAsset!, value);
+            private set
+            {
+                SetProperty(ref _islandAsset!, value);
+                SizeInTiles = _islandAsset.SizeInTiles;
+            }
         }
         private IslandAsset _islandAsset;
 
@@ -90,7 +94,7 @@ namespace AnnoMapEditor.MapTemplates.Models
         public FixedIslandElement(IslandAsset islandAsset, IslandType islandType)
             : base(islandType)
         {
-            _islandAsset = islandAsset;
+            IslandAsset = islandAsset;
 
             foreach (Slot slot in islandAsset.Slots.Values)
             {

--- a/AnnoMapEditor/MapTemplates/Models/IslandElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/IslandElement.cs
@@ -1,5 +1,6 @@
 ﻿using Anno.FileDBModels.Anno1800.MapTemplate;
 using AnnoMapEditor.MapTemplates.Enums;
+using AnnoMapEditor.Utilities;
 using IslandType = AnnoMapEditor.MapTemplates.Enums.IslandType;
 
 namespace AnnoMapEditor.MapTemplates.Models
@@ -32,10 +33,43 @@ namespace AnnoMapEditor.MapTemplates.Models
         }
         private IslandDifficulty? _islandDifficulty;
 
+        public int SizeInTiles
+        {
+            get => _sizeInTiles;
+            protected set
+            {
+                SetProperty(ref _sizeInTiles, value);
+                Area = new(Position, new Vector2(value, value));
+            }
+        }
+        private int _sizeInTiles;
+
+        public Rect2 Area
+        {
+            get => _area;
+            private set => SetProperty(ref _area, value);
+        }
+        private Rect2 _area;
+
+
 
         public IslandElement(IslandType islandType)
         {
             _islandType = islandType;
+
+            PropertyChanged += This_PropertyChanged;
+        }
+
+
+        private void This_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Position))
+                UpdateArea();
+        }
+
+        private void UpdateArea()
+        {
+            Area = new(Position, new Vector2(_sizeInTiles, _sizeInTiles));
         }
 
 

--- a/AnnoMapEditor/MapTemplates/Models/RandomIslandElement.cs
+++ b/AnnoMapEditor/MapTemplates/Models/RandomIslandElement.cs
@@ -9,7 +9,11 @@ namespace AnnoMapEditor.MapTemplates.Models
         public IslandSize IslandSize
         {
             get => _islandSize;
-            set => SetProperty(ref _islandSize, value);
+            set
+            {
+                SetProperty(ref _islandSize, value);
+                SizeInTiles = _islandSize.DefaultSizeInTiles;
+            }
         }
         private IslandSize _islandSize;
 
@@ -17,7 +21,7 @@ namespace AnnoMapEditor.MapTemplates.Models
         public RandomIslandElement(IslandSize islandSize, IslandType islandType)
             : base(islandType)
         {
-            _islandSize = islandSize;
+            IslandSize = islandSize;
         }
 
 
@@ -26,7 +30,7 @@ namespace AnnoMapEditor.MapTemplates.Models
         public RandomIslandElement(Element sourceElement)
             : base(sourceElement)
         {
-            _islandSize = IslandSize.FromElementValue(sourceElement.Size);
+            IslandSize = IslandSize.FromElementValue(sourceElement.Size);
         }
 
         protected override void ToTemplate(Element resultElement)

--- a/AnnoMapEditor/MapTemplates/Models/Session.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Session.cs
@@ -210,6 +210,9 @@ namespace AnnoMapEditor.MapTemplates.Models
 
         public void ResizeAndCommitSession(int mapSize, (int x1, int y1, int x2, int y2) playableAreaMargins)
         {
+            if (_template.MapTemplate == null)
+                throw new InvalidDataException();
+
             //Commit means write to template
             _template.MapTemplate.Size = new int[] { mapSize, mapSize };
             _template.MapTemplate.PlayableArea = new int[] { 

--- a/AnnoMapEditor/MapTemplates/Models/Session.cs
+++ b/AnnoMapEditor/MapTemplates/Models/Session.cs
@@ -58,36 +58,45 @@ namespace AnnoMapEditor.MapTemplates.Models
         }
 
 
-        public static async Task<Session?> FromA7tinfoAsync(string filePath)
+        #region loading
+
+        public static async Task<Session?> FromDataArchive(string a7tinfoPath)
         {
-            return await FromA7tinfoAsync(File.OpenRead(filePath), filePath);
+            Region region = Region.DetectFromPath(a7tinfoPath);
+            Stream? a7tinfoStream = Settings.Instance!.DataArchive.OpenRead(a7tinfoPath);
+            return await FromBinaryStreamAsync(region, a7tinfoStream);
         }
 
-        public static async Task<Session?> FromA7tinfoAsync(Stream? stream, string internalPath)
+        public static async Task<Session?> FromBinaryFileAsync(string a7tinfoPath)
         {
-            var doc = await Serializer.ReadAsync<MapTemplateDocument>(stream);
+            Region region = Region.DetectFromPath(a7tinfoPath);
+            Stream a7tinfoStream = File.OpenRead(a7tinfoPath);
+            return await FromBinaryStreamAsync(region, a7tinfoStream);
+        }
+
+        public static async Task<Session?> FromBinaryStreamAsync(Region region, Stream? a7tinfoStream)
+        {
+            var doc = await Serializer.ReadAsync<MapTemplateDocument>(a7tinfoStream);
             if (doc is null)
                 return null;
 
-            return FromTemplateDocument(doc, Region.DetectFromPath(internalPath));
+            return FromTemplateDocument(doc, region);
         }
 
-        public static async Task<Session?> FromXmlAsync(string filePath)
+        public static async Task<Session?> FromXmlFileAsync(string a7tinfoPath)
         {
-            var doc = await Serializer.ReadFromXmlAsync<MapTemplateDocument>(File.OpenRead(filePath));
+            Region region = Region.DetectFromPath(a7tinfoPath);
+            Stream a7tinfoXmlStream = File.OpenRead(a7tinfoPath);
+            return await FromXmlStreamAsync(region, a7tinfoXmlStream);
+        }
+
+        public static async Task<Session?> FromXmlStreamAsync(Region region, Stream? a7tinfoXmlStream)
+        {
+            var doc = await Serializer.ReadFromXmlAsync<MapTemplateDocument>(a7tinfoXmlStream);
             if (doc is null)
                 return null;
 
-            return FromTemplateDocument(doc, Region.DetectFromPath(filePath));
-        }
-
-        public static async Task<Session?> FromXmlAsync(Stream? stream, string internalPath)
-        {
-            var doc = await Serializer.ReadFromXmlAsync<MapTemplateDocument>(stream);
-            if (doc is null)
-                return null;
-
-            return FromTemplateDocument(doc, Region.DetectFromPath(internalPath));
+            return FromTemplateDocument(doc, region);
         }
 
         public static Session? FromTemplateDocument(MapTemplateDocument document, Region region)
@@ -120,6 +129,9 @@ namespace AnnoMapEditor.MapTemplates.Models
 
             return session;
         }
+
+        #endregion loading
+
 
         public static Session? FromNewMapDimensions(int mapSize, int playableSize, Region region)
         {

--- a/AnnoMapEditor/UI/Controls/AddIsland/AddIslandButton.xaml
+++ b/AnnoMapEditor/UI/Controls/AddIsland/AddIslandButton.xaml
@@ -1,11 +1,12 @@
-﻿<controls:DraggingControl x:Class="AnnoMapEditor.UI.Controls.AddIsland.AddIslandButton"
+﻿<dragging:DraggingControl x:Class="AnnoMapEditor.UI.Controls.AddIsland.AddIslandButton"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:controls="clr-namespace:AnnoMapEditor.UI.Controls"
-             xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls.AddIsland"
              xmlns:converters="clr-namespace:AnnoMapEditor.UI.Converters"
+             xmlns:dragging="clr-namespace:AnnoMapEditor.UI.Controls.Dragging"
+             xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls.AddIsland"
              mc:Ignorable="d"
              d:DesignWidth="800"
              d:DesignHeight="450"
@@ -13,9 +14,9 @@
              Width="{Binding IslandSize.DefaultSizeInTiles}"
              Height="{Binding IslandSize.DefaultSizeInTiles}">
 
-    <controls:DraggingControl.Resources>
+    <dragging:DraggingControl.Resources>
         <converters:NegateDoubleConverter x:Key="negateDoubleConverter" />
-    </controls:DraggingControl.Resources>
+    </dragging:DraggingControl.Resources>
 
     <Grid> 
 
@@ -45,4 +46,4 @@
         </Border>
 
     </Grid>
-</controls:DraggingControl>
+</dragging:DraggingControl>

--- a/AnnoMapEditor/UI/Controls/AddIsland/AddIslandButton.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/AddIsland/AddIslandButton.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace AnnoMapEditor.UI.Controls.AddIsland
+﻿using AnnoMapEditor.UI.Controls.Dragging;
+
+namespace AnnoMapEditor.UI.Controls.AddIsland
 {
     /// <summary>
     /// Interaction logic for AddIslandButton.xaml

--- a/AnnoMapEditor/UI/Controls/AddIsland/AddIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/AddIsland/AddIslandViewModel.cs
@@ -60,15 +60,17 @@ namespace AnnoMapEditor.UI.Controls.AddIsland
         }
 
 
-        public override void OnDragged(Vector2 newPosition)
+        public override void OnDragged(Vector2 delta)
         {
+            base.OnDragged(delta);
+
             EndDrag();
 
             // TODO: Implement proper loading!
             if (Settings.Instance.IslandRepository == null)
                 return;
 
-            IslandAdded?.Invoke(this, new(MapElementType, IslandType, IslandSize, newPosition));
+            IslandAdded?.Invoke(this, new(MapElementType, IslandType, IslandSize, delta));
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/AddIsland/AddIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/AddIsland/AddIslandViewModel.cs
@@ -2,6 +2,7 @@
 using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
 using System.Collections.Generic;
+using System.Windows;
 using System.Windows.Media;
 
 namespace AnnoMapEditor.UI.Controls.AddIsland
@@ -60,7 +61,7 @@ namespace AnnoMapEditor.UI.Controls.AddIsland
         }
 
 
-        public override void OnDragged(Vector2 delta)
+        public override void OnDragged(Point delta)
         {
             base.OnDragged(delta);
 
@@ -70,7 +71,7 @@ namespace AnnoMapEditor.UI.Controls.AddIsland
             if (Settings.Instance.IslandRepository == null)
                 return;
 
-            IslandAdded?.Invoke(this, new(MapElementType, IslandType, IslandSize, delta));
+            IslandAdded?.Invoke(this, new(MapElementType, IslandType, IslandSize, new Vector2(delta)));
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/AddIsland/AddIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/AddIsland/AddIslandViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoMapEditor.MapTemplates.Enums;
+using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
 using System.Collections.Generic;
 using System.Windows.Media;

--- a/AnnoMapEditor/UI/Controls/AddIsland/IslandAddedEvent.cs
+++ b/AnnoMapEditor/UI/Controls/AddIsland/IslandAddedEvent.cs
@@ -14,15 +14,15 @@ namespace AnnoMapEditor.UI.Controls.AddIsland
         
         public IslandSize IslandSize { get; init; }
 
-        public Vector2 Position { get; init; }
+        public Vector2 Delta { get; init; }
 
 
-        public IslandAddedEventArgs(MapElementType mapElementType, IslandType islandType, IslandSize islandSize, Vector2 position)
+        public IslandAddedEventArgs(MapElementType mapElementType, IslandType islandType, IslandSize islandSize, Vector2 delta)
         {
             MapElementType = mapElementType;
             IslandType = islandType;
             IslandSize = islandSize;
-            Position = position;
+            Delta = delta;
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/AddIsland/ProtoIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/AddIsland/ProtoIslandViewModel.cs
@@ -15,8 +15,6 @@ namespace AnnoMapEditor.UI.Controls.AddIsland
         
         public IslandSize IslandSize { get; init; }
 
-        public override int SizeInTiles => IslandSize.DefaultSizeInTiles;
-
         public override BitmapImage? Thumbnail => null;
 
         public override int ThumbnailRotation => 0;
@@ -44,6 +42,7 @@ namespace AnnoMapEditor.UI.Controls.AddIsland
                 : base(islandType)
             {
                 IslandSize = islandSize;
+                SizeInTiles = islandSize.DefaultSizeInTiles;
             }
         }
     }

--- a/AnnoMapEditor/UI/Controls/Dragging/DragEndedEvent.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DragEndedEvent.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AnnoMapEditor.UI.Controls
+namespace AnnoMapEditor.UI.Controls.Dragging
 {
     public delegate void DragEndedEventHandler(object? sender, DragEndedEventArgs e);
 

--- a/AnnoMapEditor/UI/Controls/Dragging/DragStartedEvent.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DragStartedEvent.cs
@@ -1,0 +1,9 @@
+﻿namespace AnnoMapEditor.UI.Controls.Dragging
+{
+    public delegate void DragStartedEventHandler(object? sender, DragStartedEventArgs e);
+
+
+    public class DragStartedEventArgs
+    {
+    }
+}

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
@@ -40,7 +40,7 @@ namespace AnnoMapEditor.UI.Controls.Dragging
 
         protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
         {
-            Vector2 localMousePos = new(Mouse.GetPosition(this));
+            Point localMousePos = Mouse.GetPosition(this);
             Rect2 actualSize = new(0, 0, (int)ActualWidth, (int)ActualHeight);
 
             if (localMousePos.Within(actualSize))
@@ -70,7 +70,7 @@ namespace AnnoMapEditor.UI.Controls.Dragging
         {
             if (e.LeftButton == MouseButtonState.Pressed && _viewModel.IsDragging)
             {
-                Vector2 localMousePos = new(e.GetPosition(this));
+                Point localMousePos = e.GetPosition(this);
                 _viewModel.ContinueDrag(localMousePos);
             }
         }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
@@ -40,27 +40,38 @@ namespace AnnoMapEditor.UI.Controls.Dragging
 
         protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
         {
-            Vector2 mouseOffset = new(Mouse.GetPosition(this));
-            _viewModel.BeginDrag(mouseOffset);
+            Vector2 localMousePos = new(Mouse.GetPosition(this));
+            Rect2 actualSize = new(0, 0, (int)ActualWidth, (int)ActualHeight);
+
+            if (localMousePos.Within(actualSize))
+            {
+                _viewModel.BeginDrag(localMousePos);
+                CaptureMouse();
+            }
+            else
+            {
+                ReleaseMouseCapture();
+                _viewModel.EndDrag();
+            }
 
             base.OnMouseLeftButtonDown(e);
         }
 
         protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
         {
-            _viewModel.EndDrag();
-
-            base.OnMouseLeftButtonUp(e);
+            if (_viewModel.IsDragging)
+            {
+                ReleaseMouseCapture();
+                _viewModel.EndDrag();
+            }
         }
 
         protected override void OnMouseMove(MouseEventArgs e)
         {
             if (e.LeftButton == MouseButtonState.Pressed && _viewModel.IsDragging)
             {
-                Vector2 newMouseOffset = new(e.GetPosition(this));
-                Vector2 delta = new(newMouseOffset.X - _viewModel.MouseOffset!.X, newMouseOffset.Y - _viewModel.MouseOffset!.Y);
-
-                _viewModel.OnDragged(delta);
+                Vector2 localMousePos = new(e.GetPosition(this));
+                _viewModel.ContinueDrag(localMousePos);
             }
         }
     }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
@@ -32,9 +32,9 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             if (e.PropertyName == nameof(DraggingViewModel.IsDragging))
             {
                 if (_viewModel.IsDragging)
-                    Mouse.Capture(this);
+                    CaptureMouse();
                 else
-                    Mouse.Capture(null);
+                    ReleaseMouseCapture();
             }
         }
 
@@ -54,6 +54,7 @@ namespace AnnoMapEditor.UI.Controls.Dragging
                 _viewModel.EndDrag();
             }
 
+            e.Handled = true;
             base.OnMouseLeftButtonDown(e);
         }
 
@@ -63,6 +64,8 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             {
                 ReleaseMouseCapture();
                 _viewModel.EndDrag();
+
+                e.Handled = true;
             }
         }
 
@@ -72,6 +75,8 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             {
                 Point localMousePos = e.GetPosition(this);
                 _viewModel.ContinueDrag(localMousePos);
+
+                e.Handled = true;
             }
         }
     }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
@@ -57,10 +57,10 @@ namespace AnnoMapEditor.UI.Controls.Dragging
         {
             if (e.LeftButton == MouseButtonState.Pressed && _viewModel.IsDragging)
             {
-                IInputElement parentElement = Parent as IInputElement
-                    ?? throw new Exception($"Parent of {nameof(DraggingControl)} must be an {nameof(IInputElement)}.");
-                Vector2 newPosition = new Vector2(e.GetPosition(parentElement)) - _viewModel.MouseOffset!;
-                _viewModel.OnDragged(newPosition);
+                Vector2 newMouseOffset = new(e.GetPosition(this));
+                Vector2 delta = new(newMouseOffset.X - _viewModel.MouseOffset!.X, newMouseOffset.Y - _viewModel.MouseOffset!.Y);
+
+                _viewModel.OnDragged(delta);
             }
         }
     }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingControl.cs
@@ -4,7 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
-namespace AnnoMapEditor.UI.Controls
+namespace AnnoMapEditor.UI.Controls.Dragging
 {
     public abstract class DraggingControl : UserControl
     {

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingEvent.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingEvent.cs
@@ -1,0 +1,18 @@
+﻿using AnnoMapEditor.Utilities;
+
+namespace AnnoMapEditor.UI.Controls.Dragging
+{
+    public delegate void DraggingEventHandler(object? sender, DraggingEventArgs e);
+
+
+    public class DraggingEventArgs
+    {
+        public Vector2 Delta { get; init; }
+
+
+        public DraggingEventArgs(Vector2 delta)
+        {
+            Delta = delta;
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingEvent.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingEvent.cs
@@ -1,4 +1,4 @@
-﻿using AnnoMapEditor.Utilities;
+﻿using System.Windows;
 
 namespace AnnoMapEditor.UI.Controls.Dragging
 {
@@ -7,10 +7,10 @@ namespace AnnoMapEditor.UI.Controls.Dragging
 
     public class DraggingEventArgs
     {
-        public Vector2 Delta { get; init; }
+        public Point Delta { get; init; }
 
 
-        public DraggingEventArgs(Vector2 delta)
+        public DraggingEventArgs(Point delta)
         {
             Delta = delta;
         }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
@@ -40,6 +40,6 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             DragEnded?.Invoke(this, new());
         }
 
-        public abstract void OnDragged(Vector2 newPosition);
+        public abstract void OnDragged(Vector2 delta);
     }
 }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
@@ -1,15 +1,15 @@
 ﻿using AnnoMapEditor.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Windows;
 
 namespace AnnoMapEditor.UI.Controls.Dragging
 {
     public abstract class DraggingViewModel : ObservableBase
     {
         public event DragEndedEventHandler? DragEnded;
+
+        public event DragStartedEventHandler? DragStarted;
+
+        public event DraggingEventHandler? Dragging;
 
 
         public bool IsDragging
@@ -27,10 +27,12 @@ namespace AnnoMapEditor.UI.Controls.Dragging
         private Vector2? _mouseOffset;
 
 
-        public void BeginDrag(Vector2 mouseOffset)
+        public void BeginDrag(Vector2 localMousePos)
         {
-            MouseOffset = mouseOffset;
+            MouseOffset = localMousePos;
             IsDragging = true;
+
+            DragStarted?.Invoke(this, new());
         }
 
         public void EndDrag()
@@ -40,6 +42,15 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             DragEnded?.Invoke(this, new());
         }
 
-        public abstract void OnDragged(Vector2 delta);
+        public void ContinueDrag(Vector2 localMousePos)
+        {
+            Vector2 delta = new(localMousePos.X - _mouseOffset!.X, localMousePos.Y - _mouseOffset!.Y);
+            OnDragged(delta);
+        }
+
+        public virtual void OnDragged(Vector2 delta)
+        {
+            Dragging?.Invoke(this, new(delta));
+        }
     }
 }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AnnoMapEditor.UI.Controls
+namespace AnnoMapEditor.UI.Controls.Dragging
 {
     public abstract class DraggingViewModel : ObservableBase
     {

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
@@ -19,17 +19,17 @@ namespace AnnoMapEditor.UI.Controls.Dragging
         }
         private bool _isDragging;
 
-        public Vector2? MouseOffset
+        public Point? MouseOffset
         {
             get => _mouseOffset;
             private set => SetProperty(ref _mouseOffset, value);
         }
-        private Vector2? _mouseOffset;
+        private Point? _mouseOffset;
 
 
-        public void BeginDrag(Vector2 localMousePos)
+        public void BeginDrag(Point? localMousePos = null)
         {
-            MouseOffset = localMousePos;
+            MouseOffset = localMousePos ?? new();
             IsDragging = true;
 
             DragStarted?.Invoke(this, new());
@@ -42,13 +42,13 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             DragEnded?.Invoke(this, new());
         }
 
-        public void ContinueDrag(Vector2 localMousePos)
+        public void ContinueDrag(Point localMousePos)
         {
-            Vector2 delta = new(localMousePos.X - _mouseOffset!.X, localMousePos.Y - _mouseOffset!.Y);
+            Point delta = new(localMousePos.X - _mouseOffset!.Value.X, localMousePos.Y - _mouseOffset!.Value.Y);
             OnDragged(delta);
         }
 
-        public virtual void OnDragged(Vector2 delta)
+        public virtual void OnDragged(Point delta)
         {
             Dragging?.Invoke(this, new(delta));
         }

--- a/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Dragging/DraggingViewModel.cs
@@ -42,7 +42,7 @@ namespace AnnoMapEditor.UI.Controls.Dragging
             DragEnded?.Invoke(this, new());
         }
 
-        public void ContinueDrag(Point localMousePos)
+        public virtual void ContinueDrag(Point localMousePos)
         {
             Point delta = new(localMousePos.X - _mouseOffset!.Value.X, localMousePos.Y - _mouseOffset!.Value.Y);
             OnDragged(delta);

--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -45,6 +45,9 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
             if (e.PropertyName == nameof(FixedIslandElement.IslandAsset))
                 Redraw();
+
+            if (e.PropertyName == nameof(FixedIslandElement.Position))
+                SnapContinentalIsland();
         }
 
         private void Redraw()
@@ -65,13 +68,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             _thumbnailRotation = (_fixedIsland.Rotation - 1) * -90;
 
             OnPropertyChanged(nameof(ThumbnailRotation));
-        }
-
-
-        public override void OnDragged(Vector2 newPosition)
-        {
-            base.OnDragged(newPosition);
-            SnapContinentalIsland();
         }
 
         // Rotates and snaps continental islands to the corners of the map.

--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -13,8 +13,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public override string? Label => _fixedIsland.Label;
 
-        public override int SizeInTiles => _fixedIsland.IslandAsset.SizeInTiles;
-
         public override BitmapImage? Thumbnail => _fixedIsland.IslandAsset.Thumbnail;
         
         public override int ThumbnailRotation => _thumbnailRotation ?? 90;
@@ -52,7 +50,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         private void Redraw()
         {
             OnPropertyChanged(nameof(Label));
-            OnPropertyChanged(nameof(SizeInTiles));
             OnPropertyChanged(nameof(Thumbnail));
             OnPropertyChanged(nameof(RandomizeRotation));
             UpdateThumbnailRotation();
@@ -84,7 +81,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             if (!IsOutOfBounds && _isContinentalIsland)
             {
                 Vector2 islandCenter = _fixedIsland.Position;
-                Vector2 mapCenterOffset = new((_session.Size.X - SizeInTiles) / 2, (_session.Size.Y - SizeInTiles) / 2);
+                Vector2 mapCenterOffset = new((_session.Size.X - Island.SizeInTiles) / 2, (_session.Size.Y - Island.SizeInTiles) / 2);
                 string islandFileName = System.IO.Path.GetFileNameWithoutExtension(_fixedIsland.IslandAsset.FilePath);
                 int rotationOffset = ContinentalRotationAtTop[islandFileName];
 
@@ -101,7 +98,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                     else
                     {
                         _fixedIsland.Rotation = (byte)((3 + rotationOffset) % 4);
-                        _fixedIsland.Position = new(0, _session.Size.Y - SizeInTiles);
+                        _fixedIsland.Position = new(0, _session.Size.Y - Island.SizeInTiles);
                     }
                 }
                 else
@@ -110,14 +107,14 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                     if (islandCenter.Y <= mapCenterOffset.Y)
                     {
                         _fixedIsland.Rotation = (byte)((1 + rotationOffset)%4);
-                        _fixedIsland.Position = new(_session.Size.X - SizeInTiles, 0);
+                        _fixedIsland.Position = new(_session.Size.X - Island.SizeInTiles, 0);
                     }
 
                     // top
                     else
                     {
                         _fixedIsland.Rotation = (byte)((0 + rotationOffset)%4);
-                        _fixedIsland.Position = new(_session.Size.X - SizeInTiles, _session.Size.Y - SizeInTiles);
+                        _fixedIsland.Position = new(_session.Size.X - Island.SizeInTiles, _session.Size.Y - Island.SizeInTiles);
                     }
                 }
             }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -126,7 +126,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         private static readonly Dictionary<string, int> ContinentalRotationAtTop = new Dictionary<string, int>()
         {
             { "colony01_c_01", 0 },
-            { "moderate_c_01", 1}
+            { "moderate_c_01", 1},
+            { "colony03_a03_01", 2}
         };
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml
@@ -10,8 +10,8 @@
              d:DataContext="{d:DesignInstance Type=local:RandomIslandViewModel}"
              d:DesignWidth="192"
              d:DesignHeight="192"
-             Width="{Binding SizeInTiles}"
-             Height="{Binding SizeInTiles}">
+             Width="{Binding Island.SizeInTiles}"
+             Height="{Binding Island.SizeInTiles}">
 
     <local:MapElementControl.Resources>
         <converters:NegateDoubleConverter x:Key="negateDoubleConverter" />
@@ -30,14 +30,14 @@
             <!-- Background -->
             <Rectangle Fill="{Binding BackgroundBrush}"
                        Stroke="{Binding BorderBrush}"
-                       Width="{Binding SizeInTiles}"
-                       Height="{Binding SizeInTiles}" />
+                       Width="{Binding Island.SizeInTiles}"
+                       Height="{Binding Island.SizeInTiles}" />
             
             <!-- Thumbnail -->
             <Image Visibility="{Binding Thumbnail, Converter={StaticResource collapseOnNull}}"
                    Source="{Binding Thumbnail}"
-                   Width="{Binding SizeInTiles}"
-                   Height="{Binding SizeInTiles}">
+                   Width="{Binding Island.SizeInTiles}"
+                   Height="{Binding Island.SizeInTiles}">
             </Image>
             
             <!-- rotation indicator -->
@@ -70,14 +70,14 @@
             <Line
                 X1="0"
                 Y1="0"
-                X2="{Binding SizeInTiles}"
-                Y2="{Binding SizeInTiles}" 
+                X2="{Binding Island.SizeInTiles}"
+                Y2="{Binding Island.SizeInTiles}" 
                 Stroke="#BA0024"
                 StrokeThickness="8"/>
             <Line
                 X1="0"
-                Y1="{Binding SizeInTiles}"
-                X2="{Binding SizeInTiles}"
+                Y1="{Binding Island.SizeInTiles}"
+                X2="{Binding Island.SizeInTiles}"
                 Y2="0"
                 Stroke="#BA0024"
                 StrokeThickness="8" />

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -58,8 +58,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public abstract string? Label { get; }
 
-        public abstract int SizeInTiles { get; }
-
         public virtual BitmapImage? Thumbnail { get; }
 
         public virtual int ThumbnailRotation { get; }
@@ -116,7 +114,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         public override void OnDragged(Vector2 delta)
         {
             Vector2 newPosition = Element.Position + delta;
-            Rect2 mapArea = new(_session.Size - SizeInTiles + Vector2.Tile);
+            Rect2 mapArea = new(_session.Size - Island.SizeInTiles + Vector2.Tile);
 
             // provide resistance against moving out of bounds
             if (Element.Position.Within(mapArea) && !newPosition.Within(mapArea) && delta.Length > 150)
@@ -126,7 +124,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             }
             
             base.OnDragged(delta);
-            BoundsCheck(delta);
+            BoundsCheck();
         }
 
         public void BoundsCheck()

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -113,27 +113,26 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             OnPropertyChanged(nameof(RandomizeRotation));
         }
 
-        public override void OnDragged(Vector2 newPosition)
+        public override void OnDragged(Vector2 delta)
         {
-            var mapArea = new Rect2(_session.Size - SizeInTiles + Vector2.Tile);
+            Vector2 newPosition = Element.Position + delta;
+            Rect2 mapArea = new(_session.Size - SizeInTiles + Vector2.Tile);
 
             // provide resistance against moving out of bounds
-            if (Element.Position.Within(mapArea) && !newPosition.Within(mapArea))
+            if (Element.Position.Within(mapArea) && !newPosition.Within(mapArea) && delta.Length > 150)
             {
                 Vector2 safePosition = newPosition.Clamp(mapArea);
-                if ((safePosition - newPosition).Length < 150)
-                    newPosition = safePosition;
+                delta = safePosition - Element.Position;
             }
-
-            BoundsCheck(newPosition);
-            base.OnDragged(newPosition);
+            
+            base.OnDragged(delta);
+            BoundsCheck(delta);
         }
 
-        public void BoundsCheck(Vector2? pos = null)
+        public void BoundsCheck()
         {
-            var mapArea = new Rect2(_session.Size - SizeInTiles + Vector2.Tile);
-            Vector2 position = pos ?? Element.Position;
-            IsOutOfBounds = !position.Within(mapArea);
+            Rect2 mapArea = new(_session.Size - Island.SizeInTiles + Vector2.Tile);
+            IsOutOfBounds = !Element.Position.Within(mapArea);
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -49,13 +49,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         }
         private SolidColorBrush _borderBrush = BorderBrushes["Normal"];
 
-        public bool IsOutOfBounds
-        {
-            get => _isOutOfBounds;
-            set => SetProperty(ref _isOutOfBounds, value);
-        }
-        private bool _isOutOfBounds;
-
         public abstract string? Label { get; }
 
         public virtual BitmapImage? Thumbnail { get; }
@@ -88,8 +81,12 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         {
             if (e.PropertyName == nameof(IslandElement.IslandType))
                 UpdateBackground();
+
             else if (e.PropertyName == nameof(FixedIslandElement.RandomizeRotation))
                 UpdateRotation();
+
+            else if (e.PropertyName == nameof(FixedIslandElement.Position))
+                BoundsCheck();
         }
 
         private void UpdateBackground()
@@ -111,19 +108,17 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             OnPropertyChanged(nameof(RandomizeRotation));
         }
 
-        public override void OnDragged(Vector2 delta)
+        public override void Move(Vector2 delta)
         {
             Vector2 newPosition = Element.Position + delta;
             Rect2 mapArea = new(_session.Size - Island.SizeInTiles + Vector2.Tile);
 
             // provide resistance against moving out of bounds
             if (Element.Position.Within(mapArea) && !newPosition.Within(mapArea) && delta.Length > 150)
-            {
-                Vector2 safePosition = newPosition.Clamp(mapArea);
-                delta = safePosition - Element.Position;
-            }
-            
-            base.OnDragged(delta);
+                newPosition = newPosition.Clamp(mapArea);
+
+            Element.Position = newPosition;
+
             BoundsCheck();
         }
 

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementControl.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementControl.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoMapEditor.MapTemplates.Models;
+using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
 using System;
 using System.Windows;

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementControl.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementControl.cs
@@ -45,6 +45,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         {
             _viewModel.IsSelected = true;
 
+            e.Handled = true;
             base.OnMouseLeftButtonDown(e);
         }
 
@@ -52,6 +53,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         {
             _viewModel.IsSelected = false;
 
+            e.Handled = true;
             base.OnMouseRightButtonUp(e);
         }
     }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
@@ -22,9 +22,9 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         }
 
 
-        public override void OnDragged(Vector2 newPosition)
+        public override void OnDragged(Vector2 delta)
         {
-            Element.Position = newPosition;
+            Element.Position = Element.Position + delta;
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoMapEditor.MapTemplates.Models;
+using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
 
 namespace AnnoMapEditor.UI.Controls.MapTemplates

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
@@ -34,7 +34,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public virtual void Move(Vector2 delta)
         {
-            Element.Position = Element.Position + delta;
+            Element.Position += delta;
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using AnnoMapEditor.MapTemplates.Models;
 using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
+using System.Windows;
 
 namespace AnnoMapEditor.UI.Controls.MapTemplates
 {
@@ -28,6 +29,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             Element = element;
         }
 
+
+        public virtual void Move(Point delta) => Move(new Vector2(delta));
 
         public virtual void Move(Vector2 delta)
         {

--- a/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/MapElementViewModel.cs
@@ -15,6 +15,13 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         }
         private bool _isSelected;
 
+        public bool IsOutOfBounds
+        {
+            get => _isOutOfBounds;
+            set => SetProperty(ref _isOutOfBounds, value);
+        }
+        private bool _isOutOfBounds;
+
 
         public MapElementViewModel(MapElement element)
         {
@@ -22,7 +29,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         }
 
 
-        public override void OnDragged(Vector2 delta)
+        public virtual void Move(Vector2 delta)
         {
             Element.Position = Element.Position + delta;
         }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml
@@ -1,20 +1,20 @@
-﻿<controls:DraggingControl x:Class="AnnoMapEditor.UI.Controls.MapTemplates.PlayableAreaControl"
+﻿<dragging:DraggingControl x:Class="AnnoMapEditor.UI.Controls.MapTemplates.PlayableAreaControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls.MapTemplates"
-             xmlns:controls="clr-namespace:AnnoMapEditor.UI.Controls"
              xmlns:converters="clr-namespace:AnnoMapEditor.UI.Converters"
+             xmlns:dragging="clr-namespace:AnnoMapEditor.UI.Controls.Dragging"
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance Type=local:PlayableAreaViewModel}"
              d:DesignHeight="400" d:DesignWidth="400">
 
-    <controls:DraggingControl.Resources>
+    <dragging:DraggingControl.Resources>
         <converters:BoolToVisibility x:Key="VisibleOnTrue" />
         <converters:BoolToVisibility x:Key="VisibleOnFalse" OnTrue="Collapsed" OnFalse="Visible" />
         <converters:IntToGridLengthConverter x:Key="IntToGridLength" />
-    </controls:DraggingControl.Resources>
+    </dragging:DraggingControl.Resources>
     
     <Grid>
         <Grid.ColumnDefinitions>
@@ -113,4 +113,4 @@
             </Border>
         </Grid>
     </Grid>
-</controls:DraggingControl>
+</dragging:DraggingControl>

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoMapEditor.MapTemplates.Models;
+using AnnoMapEditor.UI.Controls.Dragging;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
@@ -136,6 +136,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public override void OnDragged(Vector2 newPosition)
         {
+            base.OnDragged(newPosition);
+
             //This limits movement so that the minimum Margin is always remaining.
             Vector2 newPos = newPosition.Clamp(MinMarginVector, new Vector2(Session.Size.X - PlayableSize - MinMargin, Session.Size.Y - PlayableSize - MinMargin));
             PosX = newPos.X;

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
@@ -2,6 +2,7 @@
 using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
 using System;
+using System.Windows;
 
 namespace AnnoMapEditor.UI.Controls.MapTemplates
 {
@@ -134,12 +135,12 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         private bool _resizingInProgress = false;
 
 
-        public override void OnDragged(Vector2 newPosition)
+        public override void OnDragged(Point newPosition)
         {
             base.OnDragged(newPosition);
 
             //This limits movement so that the minimum Margin is always remaining.
-            Vector2 newPos = newPosition.Clamp(MinMarginVector, new Vector2(Session.Size.X - PlayableSize - MinMargin, Session.Size.Y - PlayableSize - MinMargin));
+            Vector2 newPos = new Vector2(newPosition).Clamp(MinMarginVector, new Vector2(Session.Size.X - PlayableSize - MinMargin, Session.Size.Y - PlayableSize - MinMargin));
             PosX = newPos.X;
             PosY = newPos.Y;
 

--- a/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/PlayableAreaViewModel.cs
@@ -1,10 +1,7 @@
 ﻿using AnnoMapEditor.MapTemplates.Models;
+using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.Utilities;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AnnoMapEditor.UI.Controls.MapTemplates
 {

--- a/AnnoMapEditor/UI/Controls/MapTemplates/RandomIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/RandomIslandViewModel.cs
@@ -11,8 +11,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         public override string? Label => _label;
         private string? _label;
 
-        public override int SizeInTiles => RandomIsland.IslandSize.DefaultSizeInTiles;
-
 
         public RandomIslandViewModel(Session session, RandomIslandElement randomIsland)
             : base(session, randomIsland)
@@ -29,9 +27,6 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         {
             if (e.PropertyName == nameof(IslandElement.IslandType) || e.PropertyName == nameof(IslandElement.Label))
                 UpdateLabel();
-
-            if (e.PropertyName == nameof(RandomIslandElement.IslandSize))
-                OnPropertyChanged(nameof(SizeInTiles));
         }
 
 

--- a/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotViewModel.cs
@@ -72,13 +72,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             IsOutOfBounds = !Element.Position.Within(_session.PlayableArea);
         }
 
-
-        private static Logger<StartingSpotViewModel> LOGGER = new();
-
         public override void Move(Vector2 delta)
         {
-            LOGGER.LogInformation("Moving " + delta);
-
             // prevent moving StartingSpots outside of the Session's playable area.
             Vector2 newPosition = Element.Position + delta;
             Element.Position = newPosition.Clamp(_session.PlayableArea);

--- a/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotViewModel.cs
@@ -61,12 +61,13 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                 BackgroundBrush = _startingSpot.Index == 0 ? Yellow : Red;
         }
 
-        public override void OnDragged(Vector2 newPosition)
+        public override void OnDragged(Vector2 delta)
         {
             // prevent moving StartingSpots outside of the Session's playable area.
-            newPosition = newPosition.Clamp(_session.PlayableArea);
+            Vector2 newPosition = Element.Position + delta;
+            Vector2 safePosition = newPosition.Clamp(_session.PlayableArea);
 
-            base.OnDragged(newPosition);
+            base.OnDragged(safePosition - Element.Position);
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotViewModel.cs
@@ -7,9 +7,9 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 {
     public class StartingSpotViewModel : MapElementViewModel
     {
-        static readonly SolidColorBrush White  = new(Color.FromArgb(255, 255, 255, 255));
+        static readonly SolidColorBrush White = new(Color.FromArgb(255, 255, 255, 255));
         static readonly SolidColorBrush Yellow = new(Color.FromArgb(255, 234, 224, 83));
-        static readonly SolidColorBrush Red    = new(Color.FromArgb(255, 234, 83, 83));
+        static readonly SolidColorBrush Red = new(Color.FromArgb(255, 234, 83, 83));
 
 
         private readonly Session _session;
@@ -43,8 +43,14 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             UpdateBackground();
 
             PropertyChanged += This_PropertyChanged;
+            startingSpot.PropertyChanged += StartingSpot_PropertyChanged;
         }
 
+        private void StartingSpot_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(StartingSpotElement.Position))
+                BoundsCheck();
+        }
 
         private void This_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
@@ -61,13 +67,21 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                 BackgroundBrush = _startingSpot.Index == 0 ? Yellow : Red;
         }
 
-        public override void OnDragged(Vector2 delta)
+        public void BoundsCheck(Vector2? pos = null)
         {
+            IsOutOfBounds = !Element.Position.Within(_session.PlayableArea);
+        }
+
+
+        private static Logger<StartingSpotViewModel> LOGGER = new();
+
+        public override void Move(Vector2 delta)
+        {
+            LOGGER.LogInformation("Moving " + delta);
+
             // prevent moving StartingSpots outside of the Session's playable area.
             Vector2 newPosition = Element.Position + delta;
-            Vector2 safePosition = newPosition.Clamp(_session.PlayableArea);
-
-            base.OnDragged(safePosition - Element.Position);
+            Element.Position = newPosition.Clamp(_session.PlayableArea);
         }
     }
 }

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using AnnoMapEditor.MapTemplates.Enums;
 using AnnoMapEditor.MapTemplates.Models;
 using AnnoMapEditor.UI.Controls.AddIsland;
+using AnnoMapEditor.UI.Controls.Dragging;
 using AnnoMapEditor.UI.Controls.MapTemplates;
 using AnnoMapEditor.UI.Overlays;
 using AnnoMapEditor.UI.Overlays.SelectIsland;

--- a/AnnoMapEditor/UI/Controls/MapView.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapView.xaml.cs
@@ -346,7 +346,7 @@ namespace AnnoMapEditor.UI.Controls
             protoIslandViewModel.DragEnded += ProtoIsland_DragEnded;
             protoIslandViewModel.IsSelected = true;
             _selectedElements.Add(protoIslandViewModel);
-            protoIslandViewModel.BeginDrag(Vector2.Zero);
+            protoIslandViewModel.BeginDrag();
         }
 
         private void ProtoIsland_DragEnded(object? sender, DragEndedEventArgs e)
@@ -555,7 +555,7 @@ namespace AnnoMapEditor.UI.Controls
                     viewModel.Dragging += MapElementViewModel_Dragging;
                     viewModel.DragEnded += MapElementViewModel_DragEnded;
                     viewModel.IsSelected = true;
-                    viewModel.BeginDrag(Vector2.Zero);
+                    viewModel.BeginDrag();
                 }
             }
         }

--- a/AnnoMapEditor/UI/Controls/Selection/SelectionBoxControl.xaml
+++ b/AnnoMapEditor/UI/Controls/Selection/SelectionBoxControl.xaml
@@ -1,0 +1,22 @@
+﻿<dragging:DraggingControl x:Class="AnnoMapEditor.UI.Controls.Selection.SelectionBoxControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AnnoMapEditor.UI.Controls.Selection"
+             xmlns:dragging="clr-namespace:AnnoMapEditor.UI.Controls.Dragging"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=local:SelectionBoxViewModel}"
+             d:DesignWidth="800"
+             d:DesignHeight="450"
+             Width="10"
+             Height="10">
+    <Grid>
+
+        <!-- Background -->
+        <Canvas Panel.ZIndex="0">
+            <Polygon Points="{Binding Boundary}" Stroke="LightGray" Fill="Gray" Opacity="0.5" />
+        </Canvas>
+    </Grid>
+
+</dragging:DraggingControl>

--- a/AnnoMapEditor/UI/Controls/Selection/SelectionBoxControl.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/Selection/SelectionBoxControl.xaml.cs
@@ -1,0 +1,31 @@
+﻿using AnnoMapEditor.UI.Controls.Dragging;
+using AnnoMapEditor.Utilities;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AnnoMapEditor.UI.Controls.Selection
+{
+    /// <summary>
+    /// Interaction logic for SelectionBox.xaml
+    /// </summary>
+    public partial class SelectionBoxControl : DraggingControl
+    {
+        public SelectionBoxControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Controls/Selection/SelectionBoxViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Selection/SelectionBoxViewModel.cs
@@ -1,0 +1,133 @@
+﻿using AnnoMapEditor.UI.Controls.Dragging;
+using AnnoMapEditor.Utilities;
+using System;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace AnnoMapEditor.UI.Controls.Selection
+{
+    public class SelectionBoxViewModel : DraggingViewModel
+    {
+        public SolidColorBrush BackgroundBrush { get; } = new(Color.FromArgb(0x0F, 0xCC, 0xCC, 0xCC));
+        public SolidColorBrush BorderBrush { get; } = new(Color.FromArgb(0x00, 0xCC, 0xCC, 0xCC));
+
+
+        public Point Start { get; init; }
+
+        public Point End
+        {
+            get => _end;
+            private set => SetProperty(ref _end, value);
+        }
+        private Point _end;
+
+        public Point Size
+        {
+            get => _size;
+            private set => SetProperty(ref _size, value);
+        }
+        private Point _size;
+
+        public Point StartLocal
+        {
+            get => _startLocal;
+            private set => SetProperty(ref _startLocal, value);
+        }
+        private Point _startLocal;
+
+        public Point EndLocal
+        {
+            get => _endLocal;
+            private set => SetProperty(ref _endLocal, value);
+        }
+        private Point _endLocal;
+
+        public PointCollection Boundary
+        {
+            get => _boundary;
+            private set => SetProperty(ref _boundary, value);
+        }
+        private PointCollection _boundary;
+
+
+        public SelectionBoxViewModel(Point start)
+        {
+            Start = start;
+            _end = start;
+            _size = new(10, 10);
+
+            UpdateOutline();
+        }
+
+
+        public override void ContinueDrag(Point localMousePos)
+        {
+            // localMousePos is relative to the control's current position
+            End = localMousePos;
+
+            UpdateOutline();
+        }
+
+        private void UpdateOutline()
+        {
+            // parallel to the map
+            if (Keyboard.IsKeyDown(Key.LeftAlt))
+            {
+                double x1 = Math.Min(Start.X, End.X);
+                double y1 = Math.Min(Start.Y, End.Y);
+                double x2 = Math.Max(Start.X, End.X);
+                double y2 = Math.Max(Start.Y, End.Y);
+
+                Boundary = new PointCollection(new Point[]
+                {
+                    new(x1, y1),
+                    new(x1, y2),
+                    new(x2, y2),
+                    new(x2, y1)
+                });
+            }
+
+            // parallel to the screen
+            else
+            {
+                Line startDecline = new(-1, -1, Start);
+                Line startIncline = new(1, -1, Start);
+                Line endDecline = new(-1, -1, End);
+                Line endIncline = new(1, -1, End);
+
+                Boundary = new PointCollection(new Point[] {
+                    Start,
+                    Line.GetIntersection(startIncline, endDecline),
+                    End,
+                    Line.GetIntersection(endIncline, startDecline),
+                });
+            }
+        }
+
+
+
+        public bool Contains(Vector2 vector) => Contains(new Point(vector.X, vector.Y));
+
+        public bool Contains(Point point)
+        {
+            bool result = false;
+
+            int j = _boundary.Count - 1;
+            for (int i = 0; i < _boundary.Count; i++)
+            {
+                Point a = _boundary[i];
+                Point b = _boundary[j];
+
+                if (a.Y < point.Y && b.Y >= point.Y || b.Y < point.Y && a.Y >= point.Y)
+                    if (a.X + (point.Y - a.Y) / (b.Y - a.Y) * (b.X - a.X) < point.X)
+                        result = !result;
+
+
+                j = i;
+            }
+
+            return result;
+        }
+    }
+}

--- a/AnnoMapEditor/UI/Windows/Main/MainWindowViewModel.cs
+++ b/AnnoMapEditor/UI/Windows/Main/MainWindowViewModel.cs
@@ -153,23 +153,21 @@ namespace AnnoMapEditor.UI.Windows.Main
             UpdateExportStatus();
         }
 
-        public async Task OpenMap(string filePath, bool fromArchive = false)
+        public async Task OpenMap(string a7tinfoPath, bool fromArchive = false)
         {
-            SessionFilePath = Path.GetFileName(filePath);
+            SessionFilePath = Path.GetFileName(a7tinfoPath);
 
             if (fromArchive)
-            {
-                Stream? fs = Settings?.DataArchive.OpenRead(filePath);
-                if (fs is not null)
-                    Session = await Session.FromA7tinfoAsync(fs, filePath);
-            }
+                Session = await Session.FromDataArchive(a7tinfoPath);
+
+            else if (Path.GetExtension(a7tinfoPath).ToLower() == ".a7tinfo")
+                Session = await Session.FromBinaryFileAsync(a7tinfoPath);
+
+            else if (Path.GetExtension(a7tinfoPath).ToLower() == ".xml")
+                Session = await Session.FromXmlFileAsync(a7tinfoPath);
+
             else
-            {
-                if (Path.GetExtension(filePath).ToLower() == ".a7tinfo")
-                    Session = await Session.FromA7tinfoAsync(filePath);
-                else
-                    Session = await Session.FromXmlAsync(filePath);
-            }
+                throw new ArgumentException();
 
             UpdateExportStatus();
         }

--- a/AnnoMapEditor/UI/Windows/Main/MainWindowViewModel.cs
+++ b/AnnoMapEditor/UI/Windows/Main/MainWindowViewModel.cs
@@ -295,8 +295,11 @@ namespace AnnoMapEditor.UI.Windows.Main
 
         private IEnumerable<String>? LoadMapsFromAssets()
         {
+            const string assetsXmlPath = "data/config/export/main/asset/assets.xml";
+
             Stopwatch stopwatch= Stopwatch.StartNew();
-            using var assetStream = Settings.DataArchive.OpenRead("data/config/export/main/asset/assets.xml");
+            using var assetStream = Settings.DataArchive.OpenRead(assetsXmlPath)
+                ?? throw new FileNotFoundException(assetsXmlPath);
             XmlDocument doc = new XmlDocument();
             doc.Load(assetStream);
             var nodes = doc.SelectNodes("//Asset[Template='MapTemplate']/Values/MapTemplate[TemplateRegion]/*[self::TemplateFilename or self::EnlargedTemplateFilename]");

--- a/AnnoMapEditor/Utilities/Line.cs
+++ b/AnnoMapEditor/Utilities/Line.cs
@@ -1,0 +1,32 @@
+﻿using System.Windows;
+
+namespace AnnoMapEditor.Utilities
+{
+
+    public class Line
+    {
+        private readonly double _a;
+
+        private readonly double _b;
+
+        private readonly double _c;
+
+
+        public Line(double a, double b, Point center)
+        {
+            _a = a;
+            _b = b;
+            _c = a * center.X + b * center.Y;
+        }
+
+
+        public static Point GetIntersection(Line p, Line q)
+        {
+            double determinant = p._a * q._b - q._a * p._b;
+            double x = (q._b * p._c - p._b * q._c) / determinant;
+            double y = (p._a * q._c - q._a * p._c) / determinant;
+
+            return new(x, y);
+        }
+    }
+}

--- a/AnnoMapEditor/Utilities/PointExtensions.cs
+++ b/AnnoMapEditor/Utilities/PointExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows;
+
+namespace AnnoMapEditor.Utilities
+{
+    public static class PointExtensions
+    {
+        public static bool Within(this Point point, Rect2 area)
+        {
+            return point.X >= area.X && point.Y >= area.Y && point.X < area.X + area.Width && point.Y < area.Y + area.Height;
+        }
+    }
+}

--- a/AnnoMapEditor/Utilities/Rect2.cs
+++ b/AnnoMapEditor/Utilities/Rect2.cs
@@ -47,10 +47,10 @@
             Size = max - Position;
         }
 
-        public Rect2(Vector2 min, Vector2 max)
+        public Rect2(Vector2 position, Vector2 size)
         {
-            Position = min;
-            Size = max - Position;
+            Position = position;
+            Size = size;
         }
     }
 }

--- a/AnnoMapEditor/Utilities/Rect2.cs
+++ b/AnnoMapEditor/Utilities/Rect2.cs
@@ -11,6 +11,7 @@
         public int Width => Size.X;
         public int Height => Size.Y;
 
+
         public Rect2(string? area)
         {
             if (area is not null)
@@ -26,6 +27,12 @@
 
             Position = Vector2.Zero;
             Size = Vector2.Zero;
+        }
+
+        public Rect2(int x1, int y1, int x2, int y2)
+        {
+            Position = new Vector2(x1, y1);
+            Size = new Vector2(x2, y2);
         }
 
         public Rect2(int[]? numbers)

--- a/AnnoMapEditor/Utilities/Vector2.cs
+++ b/AnnoMapEditor/Utilities/Vector2.cs
@@ -100,5 +100,10 @@ namespace AnnoMapEditor.Utilities
         }
 
         private static int Normalize(int x) => (x + 4) / 8 * 8;
+
+        public override string ToString()
+        {
+            return $"<{X},{Y}>";
+        }
     }
 }


### PR DESCRIPTION
This PR adds the ability to move multiple objects at once. You can select multiple objects by holding down SHIFT.

When dragging elements, the previously existing constraints apply. You cannot move StartingSpots outside of the playable area of the map. They will stop moving at the edge and thus move relative to the remainder of the selection.